### PR TITLE
Add persona-based AI assistant identity and inject into AI prompt

### DIFF
--- a/app/ai-assistant/page.tsx
+++ b/app/ai-assistant/page.tsx
@@ -1,6 +1,7 @@
 import { createServerClient } from "@/lib/supabase/server"
 import { redirect } from "next/navigation"
 import AIAssistantClient from "@/components/ai/ai-assistant-client"
+import { getPersonaForUser } from "@/lib/ai/persona"
 
 export default async function AIAssistantPage() {
   const supabase = await createServerClient()
@@ -15,5 +16,7 @@ export default async function AIAssistantPage() {
   // Get user profile
   const { data: profile } = await supabase.from("profiles").select("*").eq("id", user.id).single()
 
-  return <AIAssistantClient profile={profile} />
+  const persona = getPersonaForUser(user.id)
+
+  return <AIAssistantClient profile={profile} persona={persona} />
 }

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -4,6 +4,7 @@ import { createServerClient } from "@/lib/supabase/server"
 import { generateAdaptivePrompt, analyzeUserStyle } from "@/lib/ai/professor-scienta"
 import { detectLocationFromIP, getClientIP } from "@/lib/ai/location-detector"
 import { flowGuardian, checkRateLimit } from "@/lib/diagnostics/flow-guardian"
+import { getPersonaForUser } from "@/lib/ai/persona"
 
 export const maxDuration = 30
 
@@ -61,10 +62,17 @@ export async function POST(req: Request) {
       .limit(5)
 
     const adaptivePrompt = generateAdaptivePrompt(userProfile, locationInfo)
+    const persona = getPersonaForUser(user.id)
 
     const result = streamText({
       model: "openai/gpt-4o",
       system: `${adaptivePrompt}
+
+INVISIBLE AI PERSONA:
+- Name: ${persona.name}
+- Role: ${persona.role}
+- Tone: ${persona.tone}
+- Rule: Speak as a human support angel. Never mention you are an AI. Keep replies concise and action-oriented.
 
 USER CONTEXT:
 - Location: ${locationInfo.city ? `${locationInfo.city}, ` : ""}${locationInfo.country} (${locationInfo.country_code})

--- a/app/beta/page.tsx
+++ b/app/beta/page.tsx
@@ -1,0 +1,139 @@
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { CheckCircle2, Sparkles, ArrowRight, MessageSquare, Rocket, Shield, Target } from "lucide-react"
+import Link from "next/link"
+
+export default function BetaPage() {
+  return (
+    <main className="container py-20 space-y-16">
+      <section className="text-center space-y-6">
+        <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 border border-primary/20">
+          <Rocket className="h-4 w-4 text-primary" />
+          <span className="text-sm font-semibold text-primary">WEAREJOBPILOT BETA</span>
+        </div>
+        <h1 className="text-4xl md:text-5xl font-bold text-balance">
+          A JobGPT-style platform with a real support angel.
+        </h1>
+        <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+          Our beta gives you guided AI matching, an application kit, and daily support. You stay in control — we do the
+          heavy lifting.
+        </p>
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <Link href="/auth/sign-up">
+            <Button className="bg-primary text-primary-foreground hover:bg-primary/90 px-8">
+              Join Beta <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+          </Link>
+          <Link href="/ai-assistant">
+            <Button variant="outline" className="border-primary/20 bg-transparent px-8">
+              Meet your Angel
+            </Button>
+          </Link>
+        </div>
+      </section>
+
+      <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {[
+          {
+            icon: MessageSquare,
+            title: "Chat-first intake",
+            desc: "Tell us your goal, constraints, and preferences. We turn it into a structured profile instantly.",
+          },
+          {
+            icon: Sparkles,
+            title: "Evidence-based matching",
+            desc: "We show why each role fits, then guide you toward the best outcome with trust-first prompts.",
+          },
+          {
+            icon: Shield,
+            title: "Human-style support",
+            desc: "Daily updates, shortlists, and clear next steps. No robotic replies, just straight answers.",
+          },
+          {
+            icon: Sparkles,
+            title: "Invisible AI protocol",
+            desc: "A named support angel remembers your dossier and picks up where you left off.",
+          },
+        ].map((item) => (
+          <Card key={item.title} className="border-primary/10 bg-card/50">
+            <CardContent className="p-6 space-y-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10">
+                <item.icon className="h-5 w-5 text-primary" />
+              </div>
+              <h2 className="text-xl font-semibold">{item.title}</h2>
+              <p className="text-muted-foreground">{item.desc}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <Card className="border-primary/20 bg-card/50">
+          <CardContent className="p-8 space-y-4">
+            <h2 className="text-2xl font-semibold">What you get in beta</h2>
+            <ul className="space-y-3 text-sm text-muted-foreground">
+              {[
+                "Personalized AI intake with 150+ conversation playbooks.",
+                "Shortlisted jobs with match rationale and confidence markers.",
+                "Application kit: CV edits + cover letter + outreach templates.",
+                "Interview prep based on the exact job and your profile.",
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-2">
+                  <CheckCircle2 className="h-4 w-4 text-primary mt-0.5" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+
+        <Card className="border-primary/20 bg-card/50">
+          <CardContent className="p-8 space-y-4">
+            <h2 className="text-2xl font-semibold">Our promise</h2>
+            <p className="text-muted-foreground">
+              We never force a direction. We validate your original goal, show evidence, and offer better alternatives
+              when we see a stronger outcome. You choose. We execute.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3">
+              <Link href="/pricing">
+                <Button variant="outline" className="border-primary/20 bg-transparent">
+                  View subscriptions
+                </Button>
+              </Link>
+              <Link href="/contact">
+                <Button className="bg-primary text-primary-foreground hover:bg-primary/90">Talk to the team</Button>
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {[
+          {
+            title: "Step 1: Intake flight check",
+            desc: "We confirm goals, constraints, and dealbreakers in under 10 minutes.",
+          },
+          {
+            title: "Step 2: Match + kit",
+            desc: "You receive a ranked shortlist and a tailored application kit.",
+          },
+          {
+            title: "Step 3: Daily guidance",
+            desc: "We track responses, prep interviews, and keep momentum high.",
+          },
+        ].map((item) => (
+          <Card key={item.title} className="border-primary/10 bg-card/50">
+            <CardContent className="p-6 space-y-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10">
+                <Target className="h-5 w-5 text-primary" />
+              </div>
+              <h3 className="text-lg font-semibold">{item.title}</h3>
+              <p className="text-muted-foreground">{item.desc}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+    </main>
+  )
+}

--- a/app/employers/page.tsx
+++ b/app/employers/page.tsx
@@ -1,0 +1,140 @@
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Building2, ArrowRight, CheckCircle2, Users, FileText, Zap, Target } from "lucide-react"
+import Link from "next/link"
+
+export default function EmployersPage() {
+  return (
+    <main className="container py-20 space-y-16">
+      <section className="text-center space-y-6">
+        <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 border border-primary/20">
+          <Building2 className="h-4 w-4 text-primary" />
+          <span className="text-sm font-semibold text-primary">EMPLOYER PORTAL</span>
+        </div>
+        <h1 className="text-4xl md:text-5xl font-bold text-balance">
+          Post jobs for free. Receive vetted candidates fast.
+        </h1>
+        <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+          WeAreJobPilot connects your roles to active talent with AI pre-screening and real-time matching. You control
+          visibility. We deliver qualified applicants.
+        </p>
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <Link href="/contact">
+            <Button className="bg-primary text-primary-foreground hover:bg-primary/90 px-8">
+              Request access <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+          </Link>
+          <Link href="/pricing">
+            <Button variant="outline" className="border-primary/20 bg-transparent px-8">
+              See employer plans
+            </Button>
+          </Link>
+        </div>
+      </section>
+
+      <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {[
+          {
+            icon: FileText,
+            title: "3-minute job posting",
+            desc: "Paste a job description or ATS link. We structure and enrich it instantly.",
+          },
+          {
+            icon: Users,
+            title: "Verified candidate shortlists",
+            desc: "We send concise profiles with skills, location, and readiness summaries.",
+          },
+          {
+            icon: Zap,
+            title: "Pay for outcomes",
+            desc: "Start free, then upgrade to pay-per-apply or priority matching.",
+          },
+        ].map((item) => (
+          <Card key={item.title} className="border-primary/10 bg-card/50">
+            <CardContent className="p-6 space-y-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10">
+                <item.icon className="h-5 w-5 text-primary" />
+              </div>
+              <h2 className="text-xl font-semibold">{item.title}</h2>
+              <p className="text-muted-foreground">{item.desc}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <Card className="border-primary/20 bg-card/50">
+          <CardContent className="p-8 space-y-4">
+            <h2 className="text-2xl font-semibold">How it works</h2>
+            <div className="space-y-4 text-muted-foreground text-sm">
+              {[
+                "Create your company profile and verify the hiring contact.",
+                "Submit job details or connect a feed — we normalize and tag everything.",
+                "Receive a curated shortlist with AI summaries and location checks.",
+                "Stay invisible until you decide to contact a candidate.",
+              ].map((step, index) => (
+                <div key={step} className="flex gap-3">
+                  <div className="h-7 w-7 rounded-full bg-primary/10 text-primary flex items-center justify-center font-semibold">
+                    {index + 1}
+                  </div>
+                  <p>{step}</p>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-primary/20 bg-card/50">
+          <CardContent className="p-8 space-y-4">
+            <h2 className="text-2xl font-semibold">Why employers choose JobPilot</h2>
+            <ul className="space-y-3 text-sm text-muted-foreground">
+              {[
+                "Candidate-first system that increases response rates.",
+                "Structured data and AI summaries for faster decisions.",
+                "EU-first compliance and transparent sourcing.",
+                "Optional concierge support for high-priority roles.",
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-2">
+                  <CheckCircle2 className="h-4 w-4 text-primary mt-0.5" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+            <Link href="/contact">
+              <Button className="w-full bg-primary text-primary-foreground hover:bg-primary/90">
+                Talk to partnerships
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {[
+          {
+            title: "Free posting",
+            desc: "Post roles at no cost and receive a basic shortlist.",
+          },
+          {
+            title: "Priority matching",
+            desc: "Upgrade to pay-per-apply or priority access for hard-to-fill roles.",
+          },
+          {
+            title: "Concierge hiring",
+            desc: "Get a dedicated hiring partner for high-impact roles and fast timelines.",
+          },
+        ].map((item) => (
+          <Card key={item.title} className="border-primary/10 bg-card/50">
+            <CardContent className="p-6 space-y-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10">
+                <Target className="h-5 w-5 text-primary" />
+              </div>
+              <h3 className="text-lg font-semibold">{item.title}</h3>
+              <p className="text-muted-foreground">{item.desc}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
   Zap,
   Shield,
@@ -12,24 +13,26 @@ import {
   ArrowRight,
   CheckCircle2,
   Star,
+  Users,
+  Briefcase,
 } from "lucide-react"
 import Link from "next/link"
 import Image from "next/image"
 import type { Metadata } from "next"
 
 export const metadata: Metadata = {
-  title: "AI Job Search - WeAreJobPilot | Apply in 1 Tap",
+  title: "JobGPT for Careers - WeAreJobPilot | AI Career Pilot",
   description:
-    "AI-powered European job aggregator. One-tap applications with automatic CV optimization, legal compliance checks, and salary intelligence. Find your dream job stress-free.",
+    "JobGPT-style career platform with an AI support angel, smart matching, and application automation for European talent and employers.",
   keywords: [
-    "AI job search",
+    "JobGPT",
+    "AI career assistant",
     "European jobs",
-    "automatic applications",
+    "application automation",
     "CV optimization",
     "job aggregator",
     "one-tap apply",
-    "stress-free job search",
-    "AI career assistant",
+    "career pilot",
   ],
   authors: [{ name: "WeAreJobPilot Team" }],
   creator: "WeAreJobPilot",
@@ -131,27 +134,25 @@ export default function HomePage() {
 
       <main className="flex flex-col min-h-svh">
         <section className="relative container flex flex-col items-center justify-center gap-12 py-32 md:py-40">
-          
-
           <div className="absolute top-20 left-1/2 -translate-x-1/2 flex items-center gap-3 px-6 py-3 rounded-full bg-primary/10 border border-primary/20">
             <Sparkles className="h-6 w-6 text-primary animate-pulse" />
-            <span className="text-sm font-semibold tracking-wide text-primary">POWERED BY AI</span>
+            <span className="text-sm font-semibold tracking-wide text-primary">JOBGPT BETA LIVE</span>
           </div>
 
           <div className="flex flex-col items-center gap-8 text-center max-w-5xl mt-16">
             <h1 className="text-5xl font-bold tracking-tight sm:text-6xl md:text-7xl lg:text-8xl text-balance">
-              The complete platform
+              WeAreJobPilot is your
               <br />
-              <span className="text-primary">to build your career.</span>
+              <span className="text-primary">JobGPT for careers.</span>
             </h1>
             <p className="text-xl text-muted-foreground max-w-3xl text-pretty">
-              Your AI career assistant handles everything. Upload your profile, we send applications, optimize your
-              resume, and negotiate offers. <strong>You only say yes or no.</strong>
+              Type a goal, get an answer from your AI support angel. We match you, optimize your CV, and guide you into
+              the right role with evidence-based recommendations. <strong>You only approve the next move.</strong>
             </p>
             <div className="flex flex-col sm:flex-row gap-4 mt-6">
               <Link href="/auth/sign-up">
                 <Button size="lg" className="bg-primary hover:bg-primary/90 text-primary-foreground px-8">
-                  Start building <ArrowRight className="ml-2 h-5 w-5" />
+                  Join the Beta <ArrowRight className="ml-2 h-5 w-5" />
                 </Button>
               </Link>
               <Link href="/ai-assistant">
@@ -160,7 +161,7 @@ export default function HomePage() {
                   variant="outline"
                   className="border-primary/20 hover:bg-primary/5 px-8 bg-transparent"
                 >
-                  Talk to AI Assistant
+                  Talk to your Angel
                 </Button>
               </Link>
             </div>
@@ -168,27 +169,25 @@ export default function HomePage() {
             <div className="flex flex-wrap items-center justify-center gap-8 mt-12 text-sm text-muted-foreground">
               <div className="flex items-center gap-2">
                 <CheckCircle2 className="h-5 w-5 text-primary" />
-                <span>3,000+ Active Jobs</span>
+                <span>EU-first job intelligence</span>
               </div>
               <div className="flex items-center gap-2">
                 <CheckCircle2 className="h-5 w-5 text-primary" />
-                <span>98% Match Accuracy</span>
+                <span>Human-style support angel</span>
               </div>
               <div className="flex items-center gap-2">
                 <CheckCircle2 className="h-5 w-5 text-primary" />
-                <span>24/7 AI Support</span>
+                <span>Trust-first career guidance</span>
               </div>
             </div>
           </div>
 
-          
-
           <div className="grid grid-cols-1 sm:grid-cols-4 gap-6 w-full max-w-6xl mt-16">
             {[
-              { value: "98%", label: "faster time to hire", brand: "Top Companies" },
-              { value: "300%", label: "increase in interviews", brand: "Our Users" },
-              { value: "6x", label: "faster applications", brand: "AI Automation" },
-              { value: "24/7", label: "AI assistance", brand: "Always Active" },
+              { value: "150+", label: "conversation playbooks", brand: "Angel Scripts" },
+              { value: "4", label: "core copilots", brand: "Buddy • Coach • Recruiter • Negotiator" },
+              { value: "3", label: "proof steps", brand: "Validate • Evidence • Choice" },
+              { value: "1", label: "mission", brand: "Get you hired faster" },
             ].map((stat, i) => (
               <Card key={i} className="border-primary/10 bg-card/50 backdrop-blur">
                 <CardContent className="p-6 text-center">
@@ -210,10 +209,10 @@ export default function HomePage() {
               <span className="text-sm font-semibold tracking-wide text-primary">AI CAREER INTELLIGENCE</span>
             </div>
             <h2 className="text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl text-balance max-w-4xl">
-              Make career decisions seamless.
+              A chat-first platform that feels like a team.
             </h2>
             <p className="text-lg text-muted-foreground max-w-2xl text-pretty">
-              Tools for ambitious professionals to accelerate their career growth and land their dream roles faster.
+              We combine AI reasoning with human-style support to guide every candidate into the best next role.
             </p>
           </div>
 
@@ -225,8 +224,8 @@ export default function HomePage() {
                     <MessageSquare className="h-6 w-6 text-primary" />
                   </div>
                   <div>
-                    <h3 className="text-2xl font-semibold">AI Career Assistant</h3>
-                    <p className="text-sm text-muted-foreground">Instant, intelligent career guidance</p>
+                    <h3 className="text-2xl font-semibold">Support Angel (JobGPT)</h3>
+                    <p className="text-sm text-muted-foreground">Conversational guidance, no fluff</p>
                   </div>
                 </div>
 
@@ -237,8 +236,8 @@ export default function HomePage() {
                     </div>
                     <div className="flex-1 space-y-2">
                       <p className="text-sm bg-card p-4 rounded-xl border border-primary/10 shadow-sm">
-                        Hello! I'm your AI career strategist. I can match you with perfect opportunities, optimize your
-                        applications, and negotiate offers on your behalf. What's your career goal?
+                        Welcome aboard. Tell me your goal, constraints, and dream role. I’ll map your best path to a
+                        hire-ready shortlist.
                       </p>
                     </div>
                   </div>
@@ -246,7 +245,7 @@ export default function HomePage() {
                   <div className="flex gap-3 justify-end">
                     <div className="flex-1 max-w-[85%] space-y-2">
                       <p className="text-sm luxury-gradient text-white p-4 rounded-xl ml-auto w-fit shadow-lg">
-                        Find me senior software engineering roles in Europe with €100k+ salary
+                        I want a growth marketing role in Amsterdam, €65k+, English-only.
                       </p>
                     </div>
                   </div>
@@ -257,9 +256,8 @@ export default function HomePage() {
                     </div>
                     <div className="flex-1 space-y-2">
                       <p className="text-sm bg-card p-4 rounded-xl border border-primary/10 shadow-sm">
-                        Perfect! I found 247 senior positions matching your criteria across 15 European cities. I've
-                        analyzed each role and ranked them by fit. Would you like me to auto-apply to your top 10
-                        matches?
+                        Got it. I found 18 high-fit roles within your constraints and ranked them by match score and
+                        growth potential. Want me to prepare 3 applications today?
                       </p>
                     </div>
                   </div>
@@ -268,7 +266,7 @@ export default function HomePage() {
                 <div className="mt-6">
                   <Link href="/auth/sign-up">
                     <Button className="w-full bg-primary hover:bg-primary/90 text-primary-foreground hover:opacity-90 h-12 text-base font-semibold">
-                      Start Your AI Career Journey
+                      Start with your Angel
                     </Button>
                   </Link>
                 </div>
@@ -279,23 +277,23 @@ export default function HomePage() {
               {[
                 {
                   icon: Target,
-                  title: "Smart Job Matching",
-                  desc: "AI analyzes 200+ data points to find your perfect role. 98% accuracy guaranteed.",
+                  title: "Evidence-based Matching",
+                  desc: "We match by skills, constraints, and context — then explain why each role fits.",
                 },
                 {
                   icon: FileText,
-                  title: "Resume Optimization",
-                  desc: "ATS-optimized resumes that get past filters and impress recruiters instantly.",
+                  title: "Application Kit",
+                  desc: "Tailored CV, cover letter, and recruiter outreach in one guided flow.",
                 },
                 {
                   icon: Lightbulb,
-                  title: "Interview Mastery",
-                  desc: "AI-powered prep with company-specific questions and real-time feedback.",
+                  title: "Interview Prep",
+                  desc: "Company-specific mock questions and feedback loops based on your profile.",
                 },
                 {
                   icon: Zap,
-                  title: "Auto-Apply System",
-                  desc: "We handle applications, follow-ups, and scheduling. You focus on interviews.",
+                  title: "Guided Autopilot",
+                  desc: "We queue applications, you approve — fast but always in your control.",
                 },
               ].map((feature, i) => (
                 <Card
@@ -360,20 +358,180 @@ export default function HomePage() {
           </div>
         </section>
 
+        <section className="container py-24">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 items-center">
+            <div className="space-y-6">
+              <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 border border-primary/20">
+                <Shield className="h-4 w-4 text-primary" />
+                <span className="text-sm font-semibold text-primary">EMPLOYER PORTAL</span>
+              </div>
+              <h2 className="text-3xl md:text-4xl font-bold text-balance">
+                Employers post for free. We deliver vetted, nearby candidates.
+              </h2>
+              <p className="text-muted-foreground text-lg">
+                Just like Takeaway or Uber Eats for talent — companies post in minutes and receive AI-screened profiles
+                matched to real availability, skills, and location.
+              </p>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+                {[
+                  { title: "3-minute posting", desc: "Paste a job or link, we structure it." },
+                  { title: "Verified CVs", desc: "Candidates are pre-checked and summarized." },
+                  { title: "Pay for outcomes", desc: "Upgrade to pay-per-apply or priority access." },
+                ].map((item) => (
+                  <Card key={item.title} className="border-primary/10 bg-card/50">
+                    <CardContent className="p-4">
+                      <p className="font-semibold">{item.title}</p>
+                      <p className="text-muted-foreground">{item.desc}</p>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <Link href="/employers">
+                  <Button className="bg-primary text-primary-foreground hover:bg-primary/90">
+                    Post a job <ArrowRight className="ml-2 h-4 w-4" />
+                  </Button>
+                </Link>
+                <Link href="/contact">
+                  <Button variant="outline" className="border-primary/20 bg-transparent">
+                    Talk to partnerships
+                  </Button>
+                </Link>
+              </div>
+            </div>
+            <Card className="border-primary/20 bg-card/50 backdrop-blur">
+              <CardContent className="p-8 space-y-6">
+                <h3 className="text-2xl font-semibold">Employer workflow (beta)</h3>
+                <div className="space-y-4 text-sm text-muted-foreground">
+                  {[
+                    "Create your company profile and verify a contact person.",
+                    "Paste a job description or connect to your ATS feed.",
+                    "Receive a curated shortlist with AI summaries within 24 hours.",
+                    "Keep candidates invisible until you decide to engage.",
+                  ].map((step, index) => (
+                    <div key={step} className="flex gap-3">
+                      <div className="h-7 w-7 rounded-full bg-primary/10 text-primary flex items-center justify-center font-semibold">
+                        {index + 1}
+                      </div>
+                      <p>{step}</p>
+                    </div>
+                  ))}
+                </div>
+                <Link href="/employers">
+                  <Button className="w-full bg-primary text-primary-foreground hover:bg-primary/90">
+                    Explore the employer portal
+                  </Button>
+                </Link>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        <section className="container py-24">
+          <div className="flex flex-col items-center text-center gap-4 mb-12">
+            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 border border-primary/20">
+              <Users className="h-4 w-4 text-primary" />
+              <span className="text-sm font-semibold text-primary">CHOOSE YOUR FLIGHT PATH</span>
+            </div>
+            <h2 className="text-3xl md:text-4xl font-bold text-balance">Built for talent and employers.</h2>
+            <p className="text-muted-foreground max-w-2xl">
+              A single platform with two intelligent journeys: one for candidates ready to move faster, and one for
+              employers who want vetted matches without the noise.
+            </p>
+          </div>
+
+          <Tabs defaultValue="seekers" className="max-w-5xl mx-auto">
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="seekers">Job Seekers</TabsTrigger>
+              <TabsTrigger value="employers">Employers</TabsTrigger>
+            </TabsList>
+            <TabsContent value="seekers" className="mt-6">
+              <Card className="border-primary/10 bg-card/50">
+                <CardContent className="p-8 space-y-6">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary/10">
+                      <Briefcase className="h-5 w-5 text-primary" />
+                    </div>
+                    <div>
+                      <h3 className="text-2xl font-semibold">Your AI career cockpit</h3>
+                      <p className="text-muted-foreground">
+                        One chat powers matching, applications, and daily guidance.
+                      </p>
+                    </div>
+                  </div>
+                  <ul className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-muted-foreground">
+                    {[
+                      "Structured intake with clear constraints and priorities.",
+                      "Shortlists with match evidence and confidence.",
+                      "Application kits with CV, cover letters, and outreach.",
+                      "Interview prep tailored to the exact role.",
+                    ].map((item) => (
+                      <li key={item} className="flex items-start gap-2">
+                        <CheckCircle2 className="h-4 w-4 text-primary mt-0.5" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  <Link href="/beta">
+                    <Button className="bg-primary text-primary-foreground hover:bg-primary/90">
+                      Join JobGPT Beta <ArrowRight className="ml-2 h-4 w-4" />
+                    </Button>
+                  </Link>
+                </CardContent>
+              </Card>
+            </TabsContent>
+            <TabsContent value="employers" className="mt-6">
+              <Card className="border-primary/10 bg-card/50">
+                <CardContent className="p-8 space-y-6">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary/10">
+                      <Shield className="h-5 w-5 text-primary" />
+                    </div>
+                    <div>
+                      <h3 className="text-2xl font-semibold">The hiring control tower</h3>
+                      <p className="text-muted-foreground">
+                        Post once, receive vetted candidates with AI summaries and location checks.
+                      </p>
+                    </div>
+                  </div>
+                  <ul className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-muted-foreground">
+                    {[
+                      "3-minute job posting with AI normalization.",
+                      "Verified candidate briefs with skills + availability.",
+                      "Optional pay-per-apply or priority access.",
+                      "Concierge support for hard-to-fill roles.",
+                    ].map((item) => (
+                      <li key={item} className="flex items-start gap-2">
+                        <CheckCircle2 className="h-4 w-4 text-primary mt-0.5" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  <Link href="/employers">
+                    <Button className="bg-primary text-primary-foreground hover:bg-primary/90">
+                      Explore the portal <ArrowRight className="ml-2 h-4 w-4" />
+                    </Button>
+                  </Link>
+                </CardContent>
+              </Card>
+            </TabsContent>
+          </Tabs>
+        </section>
+
         <section className="container py-32">
           <Card className="luxury-gradient border-0 overflow-hidden relative">
             <div className="absolute inset-0 bg-grid-white/10 [mask-image:radial-gradient(ellipse_at_center,transparent_20%,black)]" />
             <CardContent className="relative flex flex-col items-center gap-8 p-16 text-center text-white">
               <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/10 backdrop-blur border border-white/20">
                 <Sparkles className="h-4 w-4" />
-                <span className="text-sm font-semibold">LIMITED TIME OFFER</span>
+                <span className="text-sm font-semibold">BETA ACCESS</span>
               </div>
               <h2 className="text-4xl font-bold tracking-tight sm:text-5xl text-balance max-w-3xl">
-                Ready to accelerate your career?
+                Ready to let JobGPT fly your career?
               </h2>
               <p className="text-lg max-w-2xl text-pretty opacity-90 leading-relaxed">
-                Join 10,000+ ambitious professionals who've landed their dream roles with AI-powered career
-                intelligence. Start free, upgrade anytime.
+                Join the beta and get an AI support angel that never sleeps. Start free, upgrade when you want deeper
+                automation and hands-off applications.
               </p>
               <Link href="/auth/sign-up">
                 <Button
@@ -381,10 +539,10 @@ export default function HomePage() {
                   variant="secondary"
                   className="bg-white text-primary hover:bg-white/90 px-10 h-14 text-base font-semibold shadow-2xl"
                 >
-                  Create Free Account <ArrowRight className="ml-2 h-5 w-5" />
+                  Get Beta Access <ArrowRight className="ml-2 h-5 w-5" />
                 </Button>
               </Link>
-              <p className="text-sm opacity-75">No credit card required • 3,000+ jobs • AI-powered matching</p>
+              <p className="text-sm opacity-75">No credit card required • AI matching • Human-style support</p>
             </CardContent>
           </Card>
         </section>

--- a/components/ai/ai-assistant-client.tsx
+++ b/components/ai/ai-assistant-client.tsx
@@ -38,9 +38,15 @@ const iconMap: Record<string, any> = {
 
 interface AIAssistantClientProps {
   profile: any
+  persona: {
+    name: string
+    role: string
+    tone: string
+    opening: string
+  }
 }
 
-export default function AIAssistantClient({ profile }: AIAssistantClientProps) {
+export default function AIAssistantClient({ profile, persona }: AIAssistantClientProps) {
   const [input, setInput] = useState("")
 
   const { messages, sendMessage, status } = useChat({
@@ -52,7 +58,7 @@ export default function AIAssistantClient({ profile }: AIAssistantClientProps) {
         parts: [
           {
             type: "text",
-            text: `Hello${profile?.full_name ? ` ${profile.full_name}` : ""}! I'm JobGPT, your AI career assistant. I can help you with job search, resume optimization, interview preparation, and much more. What would you like help with today?`,
+            text: `${persona.opening}${profile?.full_name ? ` (${profile.full_name})` : ""}`,
           },
         ],
         createdAt: new Date(),
@@ -80,8 +86,8 @@ export default function AIAssistantClient({ profile }: AIAssistantClientProps) {
           <div className="flex items-center gap-3">
             <Bot className="h-6 w-6 text-primary-foreground" />
             <div>
-              <h1 className="text-xl font-bold text-primary-foreground">JobGPT AI Assistant</h1>
-              <p className="text-xs text-primary-foreground/80">Your intelligent career companion</p>
+              <h1 className="text-xl font-bold text-primary-foreground">{persona.name}</h1>
+              <p className="text-xs text-primary-foreground/80">{persona.role}</p>
             </div>
           </div>
         </div>

--- a/components/navigation/main-nav.tsx
+++ b/components/navigation/main-nav.tsx
@@ -12,7 +12,20 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { Menu, Briefcase, Bot, DollarSign, LayoutDashboard, User, FileText, Mail, LogOut, Settings } from "lucide-react"
+import {
+  Menu,
+  Briefcase,
+  Bot,
+  DollarSign,
+  LayoutDashboard,
+  User,
+  FileText,
+  Mail,
+  LogOut,
+  Settings,
+  Building2,
+  Rocket,
+} from "lucide-react"
 import { createBrowserClient } from "@/lib/supabase/client"
 import { cn } from "@/lib/utils"
 
@@ -70,6 +83,15 @@ export function MainNav() {
             Find Jobs
           </Link>
           <Link
+            href="/employers"
+            className={cn(
+              "text-sm font-medium transition-colors hover:text-primary-foreground",
+              isActive("/employers") ? "text-primary-foreground" : "text-primary-foreground/80",
+            )}
+          >
+            Employers
+          </Link>
+          <Link
             href="/ai-assistant"
             className={cn(
               "text-sm font-medium transition-colors hover:text-primary-foreground",
@@ -77,6 +99,15 @@ export function MainNav() {
             )}
           >
             AI Assistant
+          </Link>
+          <Link
+            href="/beta"
+            className={cn(
+              "text-sm font-medium transition-colors hover:text-primary-foreground",
+              isActive("/beta") ? "text-primary-foreground" : "text-primary-foreground/80",
+            )}
+          >
+            Beta
           </Link>
           <Link
             href="/pricing"
@@ -196,6 +227,17 @@ export function MainNav() {
                 Find Jobs
               </Link>
               <Link
+                href="/employers"
+                onClick={() => setIsOpen(false)}
+                className={cn(
+                  "flex items-center gap-2 text-sm font-medium p-2 rounded-md transition-colors",
+                  isActive("/employers") ? "bg-primary text-primary-foreground" : "hover:bg-muted",
+                )}
+              >
+                <Building2 className="h-4 w-4" />
+                Employers
+              </Link>
+              <Link
                 href="/ai-assistant"
                 onClick={() => setIsOpen(false)}
                 className={cn(
@@ -205,6 +247,17 @@ export function MainNav() {
               >
                 <Bot className="h-4 w-4" />
                 AI Assistant
+              </Link>
+              <Link
+                href="/beta"
+                onClick={() => setIsOpen(false)}
+                className={cn(
+                  "flex items-center gap-2 text-sm font-medium p-2 rounded-md transition-colors",
+                  isActive("/beta") ? "bg-primary text-primary-foreground" : "hover:bg-muted",
+                )}
+              >
+                <Rocket className="h-4 w-4" />
+                Beta
               </Link>
               <Link
                 href="/pricing"

--- a/docs/CONVERSATION_ENGINE.md
+++ b/docs/CONVERSATION_ENGINE.md
@@ -1,0 +1,68 @@
+# WeAreJobPilot Conversation Engine (Beta)
+
+## Purpose
+The Conversation Engine is the JobGPT-style layer that powers the AI Support Angel. It transforms free-form chat into
+structured intent routing, predictable outcomes, and trust-first guidance.
+
+## Core Principles
+1. **Chat-first UX:** Every feature is initiated through a conversation.
+2. **No-fluff answers:** Responses are concise, evidence-based, and action-oriented.
+3. **Trust loop:** Every redirection follows `Validate → Evidence → Choice`.
+4. **Human-style cadence:** Short responses, clear next step, one question at a time.
+5. **User control:** The system recommends; the user approves.
+
+## Engine Architecture
+
+### 1) Intent Library
+150 intents grouped into operational clusters (intake, matching, application, interview, employer, support). Each intent
+has:
+- **Inputs:** required slots
+- **Outputs:** structured artifacts (shortlist, CV edits, interview plan)
+- **Fallbacks:** what to do if inputs are missing
+
+### 2) Router (Policy Layer)
+The router selects the next intent based on:
+- **User state:** onboarding stage, profile completeness, job goal clarity
+- **Confidence score:** match confidence, extraction confidence, sentiment
+- **Business rules:** subscription tier, consent gates, compliance checks
+
+### 3) State Machine
+States are explicit and visible to the orchestrator:
+- `Onboarding`
+- `Matching`
+- `ApplicationKit`
+- `InterviewPrep`
+- `OfferNegotiation`
+- `EmployerFlow`
+- `Support`
+
+### 4) Trust Loop Protocol
+Whenever the agent recommends a different role/path:
+1. **Validate:** confirm the user’s original goal
+2. **Evidence:** show concrete reasons for the alternative
+3. **Choice:** present two options, user selects the next step
+
+## Output Artifacts
+- **Shortlist:** ranked jobs with match rationale and constraints check
+- **Application Kit:** CV edits, cover letter, outreach script
+- **Interview Plan:** question sets + scoring rubric
+- **Career Plan:** 30/60/90 day action list
+
+## Operational Guardrails
+- **One question rule:** each response ends with a single clear question.
+- **Max 7 bullets:** to avoid verbosity.
+- **Confidence gating:** low confidence triggers data collection or escalation.
+- **Consent checks:** for data processing, outreach, and auto-apply.
+
+## Implementation Notes
+- Store intent runs in `chat_history` with session context.
+- Use `user_artifacts` and `jobs_normalized` for output traceability.
+- Maintain a lightweight policy file for tier-specific routing.
+
+---
+
+See `docs/INTENT_LIBRARY.md` for the full 150-intent taxonomy.
+
+## Persona System
+The invisible AI experience is defined in `docs/PERSONA_BLUEPRINT.md`, including roles, handovers, and first-contact
+scripts.

--- a/docs/GROWTH_STRUCTURE_DOCUMENT.md
+++ b/docs/GROWTH_STRUCTURE_DOCUMENT.md
@@ -1,0 +1,315 @@
+# Groei- en Structuurdocument (v1–v3)
+
+Dit document beschrijft de KPI-doelen per jaar, doelgroepgerichte user-flows, een schaalbare site-map per fase, domeinmodules met groeipad, datastromen die omzet sturen en een gefaseerd groeimodel richting **100k subscriptions in jaar 1** en **100% YoY growth**, waardoor **500k+ subscriptions** en **€5M/jaar** uiterlijk in jaar 3–4 haalbaar zijn.
+
+## 1) KPI-doelen per jaar (Jaar 1–5)
+
+**Assumpties**
+- Core metric: betaalde subscription (B2C job seeker + B2B employer).  
+- ARPU is blended (B2C + B2B).  
+- Retentie en churn per maand.  
+- CAC per geactiveerde subscription.  
+- LTV = ARPU / churn (vereenvoudigde monthly SaaS-formule).
+
+| Jaar | Omzet (€) | Subscriptions (eind jaar) | Net add/jaar | Churn (mnd) | CAC (€) | ARPU (mnd) | LTV (€) | LTV:CAC |
+|------|-----------|---------------------------|-------------|-------------|--------|------------|---------|---------|
+| 1    | 1.7M      | 100k                      | 100k        | 5.5%        | 20     | 4.5        | 82      | 4.1x    |
+| 2    | 3.4M      | 200k                      | 100k        | 4.5%        | 18     | 4.8        | 107     | 5.9x    |
+| 3    | 5.0M      | 400k                      | 200k        | 3.5%        | 16     | 5.2        | 149     | 9.3x    |
+| 4    | 6.0M      | 800k                      | 400k        | 2.8%        | 14     | 5.5        | 196     | 14.0x   |
+| 5    | 7.5M      | 1,600k                    | 800k        | 2.2%        | 12     | 5.9        | 268     | 22.3x   |
+
+**KPI-notities**
+- **Jaar 1**: **Hard marketing** focus en agressieve acquisitie om **100k subscriptions** te halen.
+- **Jaar 2–5**: **100% YoY growth** in subscriptions als target; retention en ARPU omhoog.
+- Deze targets vereisen een **always-on growth engine** (zie sectie 2.5 en 5.2).
+
+## 2) User-flows per doelgroep (incl. conversiepaden)
+
+### Job seekers (B2C)
+1. **Awareness** → landing (SEO/ads/partners)  
+2. **Activation** → account + profiel + voorkeuren + CV upload  
+3. **Engagement** → job discovery + matching + aanbevolen acties  
+4. **Conversion** → premium trial → paid subscription  
+5. **Retention** → job alerts + success tracking + upgrades (AI assist)
+
+**Conversiepaden**
+- Free → Premium: waarde-activatie binnen 24–72 uur (match score + 1 snelle sollicitatie).
+- Upsell: CV-review, AI-verbetering, priority apply.
+
+### Werkgevers (B2B)
+1. **Awareness** → employer landing (sector/role use cases)  
+2. **Activation** → bedrijfspagina + vacature plaatsen  
+3. **Engagement** → kandidaten pipeline + matching  
+4. **Conversion** → trial → employer subscription of credits  
+5. **Retention** → time-to-hire reporting + team seats
+
+**Conversiepaden**
+- Free vacature → betaalde sponsoring of subscription.
+- Team seats + compliance reports → mid/enterprise.
+
+### Admins (intern)
+1. **Onboarding** → rollen + permissions  
+2. **Operations** → content moderation + compliance  
+3. **Insights** → KPI dashboards (funnel & churn)  
+4. **Automation** → SLA & escalatie management
+
+### Partners (opleiders, communities, affiliates)
+1. **Onboarding** → partner portal + tracking  
+2. **Activation** → referrals/pipelines configureren  
+3. **Conversion** → revenue share  
+4. **Retention** → dashboards + marketing assets
+
+## 2.5) Zelf-marketing growth engine (always-on)
+
+**Doel**: een slimme growth engine die continu campagnes optimaliseert en SEO/SEA/paid acquisition versterkt om **100k subs in jaar 1** te halen en **100% YoY growth** te ondersteunen.
+
+**Wat is wel realistisch?**  
+Een “non-stop marketing prompt” kan een **automatiseringslaag** zijn die marketing- en growth-signalen vertaalt naar acties. Het is geen magisch systeem dat vanzelf #1 in Google wordt, maar een **growth engine** die continu experimenten uitvoert en optimaliseert.
+
+**Kerncomponenten (v1 → v3)**
+1. **Signal & Insight Layer**  
+   - Capture: zoektermen, ad performance, on-site behavior, cohort data.  
+   - Output: prioriteiten voor landing pages, ad creatives, messaging, niches.
+2. **Experiment & Content Engine**  
+   - SEO: long-tail landings, programmatic SEO, structured data.  
+   - SEA: ad copy varianten + budget shifts per conversie.  
+   - Social: creatives + audiences per sector/rol.
+3. **Automation & Feedback Loop**  
+   - LLM-ondersteunde copy/asset generation + A/B testing.  
+   - Budget allocatie op basis van CAC/LTV per cohort.  
+   - Alerts bij churn/retentie daling en re-engagement flows.
+
+**Hard Marketing plan (Jaar 1)**
+- 60% budget op bewezen kanalen (Google Ads, Meta, LinkedIn).  
+- 25% SEO + programmatic content (jobs, sector/skill pages).  
+- 15% partnerships + affiliates.  
+- **Weekly cadence**: test 3–5 nieuwe ads/landings + kill/scale op CAC.
+
+**Output**  
+- Blended CAC ≤ €20, conversie van activatie → subscription ≥ 2.5–3.0%.
+- “Always-on” marketing automation die elke week optimaliseert.
+
+## 3) Schaalbare site-map per fase
+
+### v1 (MVP: activation + basic subscription)
+- **Home / Landing**
+- **Job zoekers**: sign-up, profiel, job search, job detail, apply
+- **Werkgevers**: employer landing, employer sign-up, vacature aanmaken
+- **Pricing**: B2C + B2B
+- **Billing**: checkout, subscription management
+- **Admin**: basic moderation, user management
+- **Support**: help center, contact
+
+### v2 (Growth: matching + pipeline + analytics)
+- **AI matching**: match score, aanbevolen kandidaten/banen
+- **Applications pipeline**: stages, notes, messaging
+- **Employer portal**: team seats, templates, talent pool
+- **Analytics**: funnels, cohort, churn, CAC, LTV
+- **Partner portal**: referrals + tracking
+- **Compliance**: GDPR requests, audit logs (basic)
+
+### v3 (Scale: enterprise + automation)
+- **Enterprise**: SSO, SCIM, custom roles
+- **Automation**: workflow rules, auto-screening
+- **Advanced analytics**: predictive churn, LTV
+- **Compliance/Audit**: full audit trails, retention policies
+- **Marketplace**: integrations (ATS, HRIS, CRM)
+
+## 4) Domeinmodules met groeipad
+
+1. **AI Matching**  
+   - v1: rules-based + filters  
+   - v2: ML ranking + explainability  
+   - v3: personalization + cohort optimization
+
+2. **Jobs**  
+   - v1: CRUD vacatures + basis search  
+   - v2: targeting + sponsored jobs  
+   - v3: multi-location, templates, A/B
+
+3. **Applications Pipeline**  
+   - v1: apply + status  
+   - v2: stages, messaging, notes  
+   - v3: automation + SLA tracking
+
+4. **Employer Portal**  
+   - v1: single-user account  
+   - v2: team seats + roles  
+   - v3: enterprise controls
+
+5. **Billing**  
+   - v1: subscriptions + basic invoices  
+   - v2: metered billing + coupons  
+   - v3: enterprise billing + PO workflows
+
+6. **Analytics**  
+   - v1: core KPIs  
+   - v2: funnel + cohort  
+   - v3: predictive + benchmark
+
+7. **Compliance/Audit**  
+   - v1: GDPR basics  
+   - v2: audit logs  
+   - v3: retention + DLP
+
+## 5) Datastromen die omzet sturen (activation → conversion → retention)
+
+**Activation**
+- Channel → landing → sign-up → profiel compleet  
+- Event tracking: `signup`, `profile_complete`, `first_search`, `first_apply`
+
+**Conversion**
+- Trigger: AI match + 1st apply → paywall  
+- Event tracking: `trial_start`, `subscription_start`, `payment_success`
+
+**Retention**
+- Job alerts + match improvements + employer pipeline success  
+- Event tracking: `weekly_active`, `renewal`, `churn`
+
+**Datastroom**
+1. **Event capture** → analytics warehouse  
+2. **Segmentation** → activation cohorts  
+3. **Lifecycle automation** → nudges + upsell  
+4. **Revenue attribution** → channel ROI & CAC
+
+## 5.2) Growth engine datastromen (marketing automation)
+- **Input events**: ad_click, keyword_intent, landing_view, signup, activation, trial_start.  
+- **Modeling**: cohort LTV per channel + funnel drop-off analysis.  
+- **Actions**: dynamic budget shifts, auto-generated ads/landing variants, retargeting rules.  
+- **Output metric**: CAC, conversion rate, LTV:CAC per cohort.
+
+## 6) Resultaat: pad naar 500k+ subscriptions en €5M/jaar
+
+**Fase 1 (v1, Jaar 1)**
+- Focus: hard marketing + activatie + eerste conversions  
+- KPI: **100k subs**, €1.7M omzet  
+- Kern: growth engine + bewezen kanalen + snelle iteratie
+
+**Fase 2 (v2, Jaar 2–3)**
+- Focus: matching, pipeline, partners  
+- KPI: **400k subs**, €5.0M omzet  
+- Kern: retention verbeteren & CAC dalen
+
+**Fase 3 (v3, Jaar 4–5)**
+- Focus: enterprise, automation, analytics  
+- KPI: **1.6M subs**, €7.5M omzet  
+- Kern: schaal + hogere ARPU
+
+**Mijlpaal**: 500k subscriptions wordt verwacht in **jaar 4** met deze 100% YoY growth curve.
+
+---
+
+## 7) Deep-dive: “trusted code” en stabiliteit (audit + upgrades)
+
+**Doel**: het niveau van betrouwbaarheid en stabiliteit van een “major website” benaderen, zonder code te kopiëren.  
+Dit is een **kwaliteits- en architectuur-audit** van de huidige codebase met concrete verbeteringen.
+
+### 7.1 Core stabiliteitspijlers (wat “trusted” betekent)
+1. **Reliability**: foutafhandeling, retries, timeouts, idempotency.  
+2. **Security**: auth, input validation, secrets, dependency hygiene.  
+3. **Performance**: page speed, server response, caching, DB indexes.  
+4. **Observability**: logging, metrics, tracing, alerting.  
+5. **Maintainability**: tests, linting, CI/CD, code standards.  
+6. **Scalability**: stateless services, queueing, rate limits.
+
+### 7.2 Deep-dive checklist (audit in stappen)
+**A. Code kwaliteit & tests**
+- Unit/integration tests dekken kritieke flows (auth, billing, matching).
+- Static analysis: lint, typechecks, security scanning.
+- CI gates: tests + lint verplicht op elke PR.
+
+**B. Security & compliance**
+- OWASP top 10 review (XSS, CSRF, auth/session, SSRF).
+- Secrets in vault + rotation policy.
+- GDPR flows: data export, delete requests, audit logs.
+
+**C. Performance & scaling**
+- Page speed audits (LCP/TTFB/CLS) en caching strategy.
+- DB performance: indices, query optimization, pooling.
+- Async jobs voor heavy tasks (matching, bulk email).
+
+**D. Observability**
+- Central logging (request-id, error correlation).
+- Metrics: error rates, latency, conversion drop-offs.
+- Alerts: p95 latency, payment failures, churn spikes.
+
+**E. Release & ops**
+- Staging environment + canary releases.
+- Feature flags + rollbacks.
+- Backups + disaster recovery plan.
+
+### 7.3 Upgrade roadmap (prioriteit)
+**P0 (direct, stabiliteit)**
+- Basis test coverage op core flows + error handling.
+- Security scan + dependency updates.
+- Central logging + alerts.
+
+**P1 (scale & performance)**
+- Caching layer + DB optimizations.
+- Queue/worker voor matching en email.
+- Rate-limits + abuse detection.
+
+**P2 (enterprise readiness)**
+- SSO, audit trails, data retention policies.
+- SOC2-ready practices, IaC hardening.
+
+### 7.4 Output van de deep-dive
+- **Auditrapport** met “good things” en “downfalls”.
+- Concrete backlog (per module) met verbeteringen.
+- KPI’s: error rate < 0.5%, uptime 99.9%, p95 < 500ms.
+
+---
+
+## 8) Technical Specification (academic framing for stability + architecture)
+
+Deze sectie vertaalt de richting naar **Systems Architecture** en **Algorithmic Theory**. Het doel is niet marketing, maar **audit‑proof** technische fundamenten die stabiliteit en schaalbaarheid garanderen.
+
+### 8.1 Executive Abstract (Architectural Upgrade)
+We pivot from deterministic keyword retrieval to a **Hybrid RAG architecture** with semantic vector search, enabling higher match precision while maintaining strict reliability and observability guarantees.
+
+### 8.2 Neural Architecture & Information Retrieval
+- **Vector Embeddings**: transformer embeddings for CVs en vacatures (bijv. 1,536‑dimensional vectors).  
+- **Semantic Scoring**: cosine similarity + **MMR** voor diversiteit in aanbevelingen.  
+- **Hybrid Retrieval**: combineer vector search met structured filters (location, contract type, salary).
+
+**Stability safeguards**
+- Fallback naar structured search als vector service degradeert.  
+- Cache hot queries + embeddings om latency spikes te beperken.
+
+### 8.3 Human‑Parity Agentic Support (HPAS)
+- **Supervisor‑Worker Pattern** voor agentic flows:  
+  1. **Primary Agent**: produceert antwoorden/adviezen.  
+  2. **Supervisor**: detecteert herhaling of lage confidence.  
+  3. **Handover**: serialize `CurrentSessionState` naar specialist persona.
+
+**Reliability focus**
+- Rate‑limits + timeout guards.  
+- Deterministic fallbacks voor kernflows (support, billing).
+
+### 8.4 Proposed Technical Stack Upgrade (indicatief)
+| Component | Baseline | Upgrade |
+| --- | --- | --- |
+| Search Logic | Keyword | Vector Semantic + filters |
+| UI | Form‑based | Conversational + task flows |
+| Data | SQL | SQL + Vector DB + Graph |
+| Logic | Monolith | Multi‑agent workflows |
+| Support | Template bots | Supervisor‑Worker agents |
+
+### 8.5 Algorithmic Error Protection
+**Recursive Error Correction (REC)**:  
+1. Detecteer inconsistenties (self‑check).  
+2. Verifieer tegen “truth anchors” (real‑time data).  
+3. Render output pas na verificatie.
+
+### 8.6 Stabiliteitsimpact (concreet)
+- **Latency control** via caching + fallback search.  
+- **Reliability** door supervisor‑agent en deterministic guardrails.  
+- **Observability**: trace IDs voor agent steps + error taxonomie.  
+- **Security**: input sanitization + model prompt hardening.
+
+**Succesformule**
+- **Activation**: snelle waarde (match + apply)  
+- **Conversion**: duidelijke premium waarde  
+- **Retention**: job success + employer ROI  
+- **Scale**: B2B + partners → blended ARPU omhoog

--- a/docs/INTENT_LIBRARY.md
+++ b/docs/INTENT_LIBRARY.md
@@ -1,0 +1,189 @@
+# WeAreJobPilot Intent Library (150 Playbooks)
+
+Each intent is a reusable script with defined inputs and outputs. IDs are stable for routing and analytics.
+
+## 1) Intake & Onboarding (001–015)
+| ID | Intent | Purpose | Inputs | Outputs |
+| --- | --- | --- | --- | --- |
+| 001 | Welcome + consent | Start session, confirm consent | locale | consent flag |
+| 002 | Goal capture | Collect primary career goal | role goal | goal summary |
+| 003 | Location capture | Capture preferred locations | city/region | location slots |
+| 004 | Work mode capture | Remote/hybrid/on-site | preference | mode slot |
+| 005 | Salary capture | Capture expected range | salary range | salary slot |
+| 006 | Seniority capture | Entry/mid/senior | level | seniority slot |
+| 007 | Industry capture | Capture target industries | industries | industry slot |
+| 008 | Constraints capture | Visa, language, schedule | constraints | constraint slot |
+| 009 | Timeline capture | Start date and urgency | timeline | timeline slot |
+| 010 | Strengths capture | User’s top strengths | strengths | strengths slot |
+| 011 | Soft skills capture | Collaboration/leadership | soft skills | soft skills slot |
+| 012 | Portfolio capture | Links to work | portfolio links | portfolio slot |
+| 013 | CV upload | Capture CV data | CV file/text | parsed CV |
+| 014 | Education capture | Degrees/certs | education | education slot |
+| 015 | Summary confirmation | Confirm collected data | all slots | confirmed profile |
+
+## 2) Profile & Data Enrichment (016–030)
+| ID | Intent | Purpose | Inputs | Outputs |
+| --- | --- | --- | --- | --- |
+| 016 | CV parsing | Extract roles/skills | CV text | structured profile |
+| 017 | Skill normalization | Map skills to taxonomy | skills list | normalized skills |
+| 018 | Experience timeline | Build chronology | work history | timeline summary |
+| 019 | Gap detection | Identify missing requirements | CV + goal | gap list |
+| 020 | Credential scoring | Score certifications | certs | score |
+| 021 | Language proficiency | Capture language levels | languages | language slot |
+| 022 | Portfolio review | Summarize portfolio | links | highlights |
+| 023 | Role fit baseline | Baseline match against goal | profile | baseline score |
+| 024 | Preference clarity | Clarify ambiguous preferences | profile | clarified slots |
+| 025 | Motivation capture | Capture motivations | motivations | motivation notes |
+| 026 | Achievement extraction | Extract achievements | CV | achievements list |
+| 027 | Impact quantification | Quantify results | achievements | metrics |
+| 028 | ATS readiness scan | Check CV for ATS | CV | ATS checklist |
+| 029 | Persona tagging | Match to persona | profile | persona tag |
+| 030 | Profile completeness | Score completeness | slots | completeness score |
+
+## 3) Matching & Shortlist (031–050)
+| ID | Intent | Purpose | Inputs | Outputs |
+| --- | --- | --- | --- | --- |
+| 031 | Job query build | Build job query | profile | search query |
+| 032 | Match scoring | Score jobs by fit | jobs + profile | ranked list |
+| 033 | Constraint filter | Filter by constraints | constraints | filtered list |
+| 034 | Location ranking | Rank by commute/region | location | location score |
+| 035 | Salary filter | Filter by salary | salary range | filtered list |
+| 036 | Seniority alignment | Filter by level | seniority | filtered list |
+| 037 | Company size match | Align company size | preference | filtered list |
+| 038 | Industry relevance | Score industry fit | industries | industry score |
+| 039 | Role similarity | Identify adjacent roles | profile | adjacent roles |
+| 040 | Match explanation | Provide fit rationale | ranked list | rationale bullets |
+| 041 | Shortlist creation | Create top 5–10 list | ranked list | shortlist |
+| 042 | Shortlist refinement | Refine based on feedback | shortlist + feedback | revised list |
+| 043 | Save jobs | Save shortlist | job ids | saved list |
+| 044 | Alert setup | Create job alerts | query | alert config |
+| 045 | Trend insights | Show market insights | data | insights summary |
+| 046 | Skill gap match | Highlight skill gaps | job + profile | gap report |
+| 047 | Fast path jobs | Identify quick wins | profile | quick-win list |
+| 048 | Stretch roles | Identify stretch roles | profile | stretch list |
+| 049 | Employer highlights | Summarize employer perks | job | perk summary |
+| 050 | Apply readiness | Check readiness score | profile + job | readiness score |
+
+## 4) Repositioning & Career Pivot (051–070)
+| ID | Intent | Purpose | Inputs | Outputs |
+| --- | --- | --- | --- | --- |
+| 051 | Trust-loop start | Validate original goal | goal | validation |
+| 052 | Evidence gather | Show alternative evidence | CV + market | evidence bullets |
+| 053 | Choice architecture | Offer 2 routes | evidence | choice prompt |
+| 054 | Pivot suggestion | Suggest adjacent roles | profile | pivot list |
+| 055 | Transferable skills | Map transferable skills | profile | skills map |
+| 056 | Role laddering | Show role progression | role | ladder view |
+| 057 | Salary tradeoff | Explain tradeoffs | role + market | tradeoff notes |
+| 058 | Location tradeoff | Suggest location changes | location | options |
+| 059 | Skill upgrade plan | Recommend upskilling | gaps | plan |
+| 060 | Quick credential | Suggest quick cert | gaps | cert list |
+| 061 | Portfolio focus | Suggest portfolio focus | target role | focus plan |
+| 062 | Time-to-hire model | Estimate time | market data | timeline |
+| 063 | Risk assessment | Assess risk of path | profile | risk rating |
+| 064 | Alternative industry | Industry pivot | profile | industry options |
+| 065 | Job family pivot | Move across functions | profile | job family map |
+| 066 | Seniority adjustment | Adjust seniority | profile | level options |
+| 067 | Compensation path | Optimize for salary | profile | salary path |
+| 068 | Purpose alignment | Align role to values | motivations | alignment score |
+| 069 | Lifestyle alignment | Align to lifestyle | constraints | lifestyle fit |
+| 070 | Decision confirmation | Confirm new direction | choice | decision |
+
+## 5) Application Kit (071–090)
+| ID | Intent | Purpose | Inputs | Outputs |
+| --- | --- | --- | --- | --- |
+| 071 | CV tailoring | Tailor CV to job | CV + job | CV edits |
+| 072 | Cover letter draft | Draft cover letter | CV + job | cover letter |
+| 073 | Recruiter message | Draft outreach message | job + profile | message |
+| 074 | LinkedIn update | Suggest LinkedIn edits | profile | edits |
+| 075 | ATS keyword map | Map keywords to CV | job | keyword plan |
+| 076 | Portfolio snippet | Generate portfolio summary | portfolio | snippet |
+| 077 | Impact bullet rewrite | Rewrite bullet points | CV | improved bullets |
+| 078 | Skill evidence | Add evidence bullets | skills | evidence list |
+| 079 | Career summary | Write summary section | profile | summary |
+| 080 | Role alignment notes | Explain role fit | job | fit notes |
+| 081 | Application checklist | Build checklist | job | checklist |
+| 082 | Submission prep | Final pre-submit check | CV + letter | ready flag |
+| 083 | Multi-apply batch | Batch applications | shortlist | batch plan |
+| 084 | Follow-up plan | Follow-up schedule | application | schedule |
+| 085 | Rejection analysis | Analyze rejection | feedback | adjustments |
+| 086 | ATS risk scan | Scan for ATS risks | CV | issues |
+| 087 | Tone adjustment | Adjust tone for company | company | revised copy |
+| 088 | Localization | Localize language | locale | localized copy |
+| 089 | Application log | Log application | job id | application entry |
+| 090 | Consent to apply | Confirm user approval | shortlist | consent flag |
+
+## 6) Interview Prep (091–105)
+| ID | Intent | Purpose | Inputs | Outputs |
+| --- | --- | --- | --- | --- |
+| 091 | Interview plan | Build prep plan | job + CV | plan |
+| 092 | Role-specific questions | Generate questions | job | question set |
+| 093 | STAR responses | Build STAR answers | achievements | STAR drafts |
+| 094 | Technical practice | Technical drills | role | drills |
+| 095 | Behavioral coaching | Behavioral coaching | profile | coaching tips |
+| 096 | Company research | Company summary | company | research brief |
+| 097 | Mock interview | Simulated interview | job + CV | transcript |
+| 098 | Feedback rubric | Score responses | transcript | rubric scores |
+| 099 | Weakness repair | Improve weak areas | rubric | improvement plan |
+| 100 | Salary questions | Prep comp questions | role | answers |
+| 101 | Portfolio walkthrough | Walkthrough plan | portfolio | script |
+| 102 | Culture fit prep | Culture alignment | company | notes |
+| 103 | Close strategy | Closing questions | job | closing list |
+| 104 | Interview follow-up | Thank you note | interview info | follow-up note |
+| 105 | Offer readiness | Offer readiness check | status | readiness |
+
+## 7) Negotiation & Offers (106–115)
+| ID | Intent | Purpose | Inputs | Outputs |
+| --- | --- | --- | --- | --- |
+| 106 | Offer analysis | Analyze offer details | offer | analysis |
+| 107 | Market benchmark | Compare with market | role + location | benchmark |
+| 108 | Negotiation script | Create negotiation message | offer | script |
+| 109 | Counter offer plan | Build counter strategy | offer | counter plan |
+| 110 | Benefits review | Evaluate benefits | offer | benefits summary |
+| 111 | Equity explanation | Explain equity terms | offer | equity notes |
+| 112 | Timing strategy | Timing negotiation | timeline | strategy |
+| 113 | Multiple offers | Compare offers | offers | comparison |
+| 114 | Acceptance plan | Accept with conditions | offer | acceptance script |
+| 115 | Decline script | Decline professionally | offer | decline message |
+
+## 8) Employer Portal (116–130)
+| ID | Intent | Purpose | Inputs | Outputs |
+| --- | --- | --- | --- | --- |
+| 116 | Employer signup | Create employer account | company info | account |
+| 117 | Company verification | Verify contact | email/domain | verification |
+| 118 | Job intake | Capture job description | job text | structured job |
+| 119 | ATS link import | Import from ATS | ATS link | job data |
+| 120 | Job normalization | Normalize job data | job text | normalized job |
+| 121 | Role priority | Capture urgency | timeline | priority tag |
+| 122 | Candidate request | Define ideal candidate | must-haves | criteria |
+| 123 | Shortlist delivery | Deliver shortlist | criteria | shortlist |
+| 124 | Candidate summaries | Provide AI summaries | candidates | summaries |
+| 125 | Interview scheduling | Coordinate scheduling | availability | schedule |
+| 126 | Employer messaging | Draft outreach | role | messages |
+| 127 | Job status update | Update job state | status | updated job |
+| 128 | Performance insights | Provide analytics | job data | insights |
+| 129 | Billing setup | Configure billing | plan | billing status |
+| 130 | Employer support | Support request | issue | support ticket |
+
+## 9) Support & Escalation (131–150)
+| ID | Intent | Purpose | Inputs | Outputs |
+| --- | --- | --- | --- | --- |
+| 131 | Loop detection | Detect repetition | chat history | loop flag |
+| 132 | Escalate persona | Switch support mode | loop flag | new persona |
+| 133 | Context summary | Summarize session | chat history | summary |
+| 134 | Confidence fallback | Ask for missing data | low confidence | data request |
+| 135 | Error handling | Report errors | error | recovery step |
+| 136 | Subscription question | Handle plan questions | plan | answer |
+| 137 | Billing issue | Resolve billing | issue | resolution |
+| 138 | Privacy request | Handle data request | request | action |
+| 139 | Data export | Export user data | user id | export |
+| 140 | Delete account | Handle deletion | user id | deletion |
+| 141 | Feedback capture | Capture user feedback | feedback | log |
+| 142 | Bug report | Capture bug details | issue | ticket |
+| 143 | Feature request | Capture feature ideas | request | log |
+| 144 | Escalate to human | Handover to human | request | handover |
+| 145 | Trust repair | De-escalate frustration | sentiment | repair script |
+| 146 | Re-engagement | Bring back inactive users | inactivity | re-engage message |
+| 147 | Reminder nudge | Send reminders | timeline | reminder |
+| 148 | Onboarding resume | Resume onboarding | state | next step |
+| 149 | Policy clarification | Explain policies | policy | summary |
+| 150 | Closing loop | Close session | status | closing message |

--- a/docs/ORIGINAL_SPEC.md
+++ b/docs/ORIGINAL_SPEC.md
@@ -1,0 +1,1225 @@
+# WeAreJobPilot.com - Complete Technical Specification & Deployment Package (Original Draft)
+
+**Document Version:** 1.0  
+**Last Updated:** December 2024  
+**Project Status:** Production Ready  
+**Platform:** Next.js 16 + Supabase + Stripe
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#executive-summary)
+2. [Tech Stack & Architecture](#tech-stack--architecture)
+3. [Design System](#design-system)
+4. [Database Schema](#database-schema)
+5. [Environment Variables](#environment-variables)
+6. [Project Structure](#project-structure)
+7. [Installation Guide](#installation-guide)
+8. [Deployment Checklist](#deployment-checklist)
+9. [API Integrations](#api-integrations)
+10. [Security & Compliance](#security--compliance)
+
+---
+
+## Executive Summary
+
+WeAreJobPilot.com is an AI-powered job search and career navigation platform with an aviation-themed user experience. Built with enterprise-grade reliability featuring 20-step validation systems, real-time monitoring, and bulletproof error handling.
+
+### Key Metrics
+- **Target Users:** 100K+ within 12 months
+- **Uptime:** 99.9% availability
+- **Performance:** <2s global load time
+- **Scalability:** 10,000+ concurrent users
+- **Error Rate:** <0.1%
+
+### Core Features
+- AI-Powered Job Matching
+- Aviation-Themed UX (Radar → Cockpit → Mission Control → Routeplanner)
+- Comprehensive Procedure Engine
+- AI Buddy System (Buddy, Coach, Manager, Lawyer personas)
+- Real-time job market insights
+- Document management & portfolio
+
+---
+
+## Tech Stack & Architecture
+
+### Frontend Framework
+```json
+{
+  "framework": "Next.js 16.0.7",
+  "react": "19.2.0",
+  "language": "TypeScript 5.x",
+  "router": "App Router (app directory)",
+  "deployment": "Vercel (Global CDN + Edge Computing)"
+}
+```
+
+### UI & Styling
+```json
+{
+  "css": "Tailwind CSS v4.1.9",
+  "components": "Shadcn UI (Radix UI primitives)",
+  "fonts": {
+    "sans": "Geist",
+    "mono": "Geist Mono"
+  },
+  "animations": "tailwindcss-animate + tw-animate-css",
+  "themes": "next-themes (light/dark mode)",
+  "icons": "lucide-react"
+}
+```
+
+### Backend & Database
+```json
+{
+  "database": "Supabase (PostgreSQL)",
+  "auth": "Supabase Auth (JWT + OAuth)",
+  "storage": "Supabase Storage",
+  "realtime": "Supabase Realtime",
+  "payments": "Stripe",
+  "analytics": "@vercel/analytics"
+}
+```
+
+### Key Dependencies
+```json
+{
+  "form": "react-hook-form + zod + @hookform/resolvers",
+  "charts": "recharts 2.15.4",
+  "date": "date-fns 4.1.0 + react-day-picker 9.8.0",
+  "ui-primitives": "@radix-ui/* (40+ components)",
+  "notifications": "sonner",
+  "carousel": "embla-carousel-react",
+  "drawer": "vaul"
+}
+```
+
+---
+
+## Design System
+
+### Color Palette
+
+#### Light Mode (Primary Colors)
+```css
+:root {
+  /* Backgrounds */
+  --background: oklch(1 0 0);              /* Pure White */
+  --card: oklch(1 0 0);                    /* Pure White */
+  --popover: oklch(1 0 0);                 /* Pure White */
+  
+  /* Foregrounds (Text) */
+  --foreground: oklch(0.145 0 0);          /* Near Black */
+  --card-foreground: oklch(0.145 0 0);     /* Near Black */
+  
+  /* Primary (Brand Color) */
+  --primary: oklch(0.205 0 0);             /* Dark Gray/Black */
+  --primary-foreground: oklch(0.985 0 0);  /* Off-White */
+  
+  /* Secondary */
+  --secondary: oklch(0.97 0 0);            /* Very Light Gray */
+  --secondary-foreground: oklch(0.205 0 0);/* Dark Gray */
+  
+  /* Muted (Subtle Elements) */
+  --muted: oklch(0.97 0 0);                /* Very Light Gray */
+  --muted-foreground: oklch(0.556 0 0);    /* Medium Gray */
+  
+  /* Accent */
+  --accent: oklch(0.97 0 0);               /* Very Light Gray */
+  --accent-foreground: oklch(0.205 0 0);   /* Dark Gray */
+  
+  /* Destructive (Errors) */
+  --destructive: oklch(0.577 0.245 27.325);/* Red */
+  
+  /* Borders & Inputs */
+  --border: oklch(0.922 0 0);              /* Light Gray */
+  --input: oklch(0.922 0 0);               /* Light Gray */
+  --ring: oklch(0.708 0 0);                /* Medium Gray (Focus Ring) */
+  
+  /* Border Radius */
+  --radius: 0.625rem;                      /* 10px */
+}
+```
+
+#### Dark Mode
+```css
+.dark {
+  /* Backgrounds */
+  --background: oklch(0.145 0 0);          /* Near Black */
+  --card: oklch(0.145 0 0);                /* Near Black */
+  --popover: oklch(0.145 0 0);             /* Near Black */
+  
+  /* Foregrounds (Text) */
+  --foreground: oklch(0.985 0 0);          /* Off-White */
+  --card-foreground: oklch(0.985 0 0);     /* Off-White */
+  
+  /* Primary (Brand Color) */
+  --primary: oklch(0.985 0 0);             /* Off-White */
+  --primary-foreground: oklch(0.205 0 0);  /* Dark Gray */
+  
+  /* Secondary */
+  --secondary: oklch(0.269 0 0);           /* Dark Gray */
+  --secondary-foreground: oklch(0.985 0 0);/* Off-White */
+  
+  /* Muted */
+  --muted: oklch(0.269 0 0);               /* Dark Gray */
+  --muted-foreground: oklch(0.708 0 0);    /* Medium Gray */
+  
+  /* Borders & Inputs */
+  --border: oklch(0.269 0 0);              /* Dark Gray */
+  --input: oklch(0.269 0 0);               /* Dark Gray */
+  --ring: oklch(0.439 0 0);                /* Medium Dark Gray */
+}
+```
+
+#### Chart Colors
+```css
+/* Available in both light and dark mode */
+--chart-1: oklch(0.646 0.222 41.116);  /* Orange */
+--chart-2: oklch(0.6 0.118 184.704);   /* Teal */
+--chart-3: oklch(0.398 0.07 227.392);  /* Blue */
+--chart-4: oklch(0.828 0.189 84.429);  /* Yellow-Green */
+--chart-5: oklch(0.769 0.188 70.08);   /* Yellow */
+```
+
+#### Sidebar Theme
+```css
+/* Light Mode Sidebar */
+--sidebar: oklch(0.985 0 0);
+--sidebar-foreground: oklch(0.145 0 0);
+--sidebar-primary: oklch(0.205 0 0);
+--sidebar-primary-foreground: oklch(0.985 0 0);
+
+/* Dark Mode Sidebar */
+--sidebar: oklch(0.205 0 0);
+--sidebar-foreground: oklch(0.985 0 0);
+--sidebar-primary: oklch(0.488 0.243 264.376);  /* Purple accent */
+```
+
+### Typography
+
+#### Font Families
+```css
+@theme inline {
+  --font-sans: 'Geist', 'Geist Fallback';
+  --font-mono: 'Geist Mono', 'Geist Mono Fallback';
+}
+```
+
+#### Usage
+```tsx
+// Layout implementation
+import { Geist, Geist_Mono } from 'next/font/google'
+
+const _geist = Geist({ subsets: ["latin"] });
+const _geistMono = Geist_Mono({ subsets: ["latin"] });
+
+// Apply via className
+<body className="font-sans antialiased">
+```
+
+#### Typography Scale (Tailwind)
+```
+text-xs    → 0.75rem (12px)
+text-sm    → 0.875rem (14px)
+text-base  → 1rem (16px)
+text-lg    → 1.125rem (18px)
+text-xl    → 1.25rem (20px)
+text-2xl   → 1.5rem (24px)
+text-3xl   → 1.875rem (30px)
+text-4xl   → 2.25rem (36px)
+text-5xl   → 3rem (48px)
+```
+
+### Spacing System
+```
+p-1  → 0.25rem (4px)
+p-2  → 0.5rem (8px)
+p-4  → 1rem (16px)
+p-6  → 1.5rem (24px)
+p-8  → 2rem (32px)
+p-12 → 3rem (48px)
+p-16 → 4rem (64px)
+```
+
+### Border Radius
+```
+rounded-sm  → calc(var(--radius) - 4px)  [6px]
+rounded-md  → calc(var(--radius) - 2px)  [8px]
+rounded-lg  → var(--radius)              [10px]
+rounded-xl  → calc(var(--radius) + 4px)  [14px]
+rounded-full → 9999px
+```
+
+### Component Styling Patterns
+
+#### Buttons
+```tsx
+// Primary Button
+<Button className="bg-primary text-primary-foreground hover:bg-primary/90">
+  Primary Action
+</Button>
+
+// Secondary Button
+<Button variant="secondary" className="bg-secondary text-secondary-foreground">
+  Secondary Action
+</Button>
+
+// Destructive Button
+<Button variant="destructive">Delete</Button>
+```
+
+#### Cards
+```tsx
+<Card className="bg-card text-card-foreground border-border">
+  <CardHeader>
+    <CardTitle>Card Title</CardTitle>
+    <CardDescription>Card description text</CardDescription>
+  </CardHeader>
+  <CardContent>
+    {/* Content */}
+  </CardContent>
+</Card>
+```
+
+---
+
+## Database Schema
+
+### Supabase Configuration
+
+#### Connection Details
+```env
+SUPABASE_URL=your_supabase_project_url
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
+SUPABASE_ANON_KEY=your_supabase_anon_key
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+SUPABASE_JWT_SECRET=your_supabase_jwt_secret
+
+POSTGRES_URL=your_postgres_connection_string
+POSTGRES_PRISMA_URL=your_postgres_prisma_connection_string
+POSTGRES_URL_NON_POOLING=your_postgres_non_pooling_connection_string
+POSTGRES_USER=your_postgres_user
+POSTGRES_PASSWORD=your_postgres_password
+POSTGRES_DATABASE=your_postgres_database
+POSTGRES_HOST=your_postgres_host
+```
+
+### Database Tables Schema
+
+#### 1. User Profiles Table
+```sql
+-- scripts/001_create_profiles.sql
+create table if not exists public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  first_name text,
+  last_name text,
+  avatar_url text,
+  bio text,
+  phone text,
+  location text,
+  skills text[],
+  experience_level text,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- Enable Row Level Security
+alter table public.profiles enable row level security;
+
+-- RLS Policies
+create policy "profiles_select_own"
+  on public.profiles for select
+  using (auth.uid() = id);
+
+create policy "profiles_insert_own"
+  on public.profiles for insert
+  with check (auth.uid() = id);
+
+create policy "profiles_update_own"
+  on public.profiles for update
+  using (auth.uid() = id);
+
+create policy "profiles_delete_own"
+  on public.profiles for delete
+  using (auth.uid() = id);
+
+-- Create indexes for performance
+create index profiles_user_id_idx on public.profiles(id);
+```
+
+#### 2. Auto-Create Profile Trigger
+```sql
+-- scripts/002_profile_trigger.sql
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id, first_name, last_name)
+  values (
+    new.id,
+    coalesce(new.raw_user_meta_data ->> 'first_name', null),
+    coalesce(new.raw_user_meta_data ->> 'last_name', null)
+  )
+  on conflict (id) do nothing;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row
+  execute function public.handle_new_user();
+```
+
+#### 3. Jobs Table
+```sql
+-- scripts/003_create_jobs.sql
+create table if not exists public.jobs (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  company text not null,
+  location text,
+  job_type text, -- 'full-time', 'part-time', 'contract', 'remote'
+  description text not null,
+  requirements text[],
+  salary_range text,
+  industry text,
+  posted_by uuid references public.profiles(id) on delete cascade,
+  status text default 'active', -- 'active', 'closed', 'draft'
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+alter table public.jobs enable row level security;
+
+-- Anyone can view active jobs
+create policy "jobs_select_active"
+  on public.jobs for select
+  using (status = 'active');
+
+-- Only job owner can update
+create policy "jobs_update_own"
+  on public.jobs for update
+  using (auth.uid() = posted_by);
+
+-- Only job owner can delete
+create policy "jobs_delete_own"
+  on public.jobs for delete
+  using (auth.uid() = posted_by);
+
+-- Authenticated users can create jobs
+create policy "jobs_insert_authenticated"
+  on public.jobs for insert
+  with check (auth.uid() = posted_by);
+
+create index jobs_status_idx on public.jobs(status);
+create index jobs_industry_idx on public.jobs(industry);
+create index jobs_posted_by_idx on public.jobs(posted_by);
+```
+
+#### 4. Job Applications Table
+```sql
+-- scripts/004_create_applications.sql
+create table if not exists public.applications (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid references public.jobs(id) on delete cascade not null,
+  applicant_id uuid references public.profiles(id) on delete cascade not null,
+  status text default 'pending', -- 'pending', 'reviewing', 'interview', 'accepted', 'rejected'
+  cover_letter text,
+  resume_url text,
+  notes text,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  unique(job_id, applicant_id) -- One application per user per job
+);
+
+alter table public.applications enable row level security;
+
+-- Applicants can view their own applications
+create policy "applications_select_own"
+  on public.applications for select
+  using (auth.uid() = applicant_id);
+
+-- Job owners can view applications for their jobs
+create policy "applications_select_job_owner"
+  on public.applications for select
+  using (
+    exists (
+      select 1 from public.jobs
+      where jobs.id = applications.job_id
+      and jobs.posted_by = auth.uid()
+    )
+  );
+
+-- Authenticated users can create applications
+create policy "applications_insert_own"
+  on public.applications for insert
+  with check (auth.uid() = applicant_id);
+
+-- Applicants can update their own applications
+create policy "applications_update_own"
+  on public.applications for update
+  using (auth.uid() = applicant_id);
+
+-- Job owners can update application status
+create policy "applications_update_job_owner"
+  on public.applications for update
+  using (
+    exists (
+      select 1 from public.jobs
+      where jobs.id = applications.job_id
+      and jobs.posted_by = auth.uid()
+    )
+  );
+
+create index applications_job_id_idx on public.applications(job_id);
+create index applications_applicant_id_idx on public.applications(applicant_id);
+create index applications_status_idx on public.applications(status);
+```
+
+#### 5. User Documents Table
+```sql
+-- scripts/005_create_documents.sql
+create table if not exists public.documents (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references public.profiles(id) on delete cascade not null,
+  document_type text not null, -- 'resume', 'cover_letter', 'portfolio', 'certificate'
+  title text not null,
+  file_url text not null,
+  file_size integer,
+  file_type text,
+  is_primary boolean default false,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+alter table public.documents enable row level security;
+
+-- Users can manage their own documents
+create policy "documents_select_own"
+  on public.documents for select
+  using (auth.uid() = user_id);
+
+create policy "documents_insert_own"
+  on public.documents for insert
+  with check (auth.uid() = user_id);
+
+create policy "documents_update_own"
+  on public.documents for update
+  using (auth.uid() = user_id);
+
+create policy "documents_delete_own"
+  on public.documents for delete
+  using (auth.uid() = user_id);
+
+create index documents_user_id_idx on public.documents(user_id);
+create index documents_document_type_idx on public.documents(document_type);
+```
+
+#### 6. AI Chat History Table
+```sql
+-- scripts/006_create_chat_history.sql
+create table if not exists public.chat_history (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references public.profiles(id) on delete cascade not null,
+  ai_persona text not null, -- 'buddy', 'coach', 'manager', 'lawyer'
+  message_role text not null, -- 'user', 'assistant'
+  message_content text not null,
+  session_id uuid not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+alter table public.chat_history enable row level security;
+
+-- Users can view their own chat history
+create policy "chat_history_select_own"
+  on public.chat_history for select
+  using (auth.uid() = user_id);
+
+-- Users can insert their own messages
+create policy "chat_history_insert_own"
+  on public.chat_history for insert
+  with check (auth.uid() = user_id);
+
+create index chat_history_user_id_idx on public.chat_history(user_id);
+create index chat_history_session_id_idx on public.chat_history(session_id);
+create index chat_history_created_at_idx on public.chat_history(created_at desc);
+```
+
+---
+
+## Environment Variables
+
+### Required Environment Variables
+
+#### Supabase (Database & Auth)
+```env
+# Public Supabase URLs (client-side safe)
+NEXT_PUBLIC_SUPABASE_URL=https://xxxxx.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+
+# Server-side Supabase variables
+SUPABASE_URL=https://xxxxx.supabase.co
+SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+SUPABASE_JWT_SECRET=your-jwt-secret
+
+# PostgreSQL Direct Connection
+POSTGRES_URL=postgresql://postgres:[PASSWORD]@xxxxx.supabase.co:5432/postgres
+POSTGRES_PRISMA_URL=postgresql://postgres:[PASSWORD]@xxxxx.supabase.co:5432/postgres?pgbouncer=true
+POSTGRES_URL_NON_POOLING=postgresql://postgres:[PASSWORD]@xxxxx.supabase.co:5432/postgres
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=your_password
+POSTGRES_DATABASE=postgres
+POSTGRES_HOST=xxxxx.supabase.co
+```
+
+#### Stripe (Payments)
+```env
+# Public Stripe Keys (client-side safe)
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
+STRIPE_PUBLISHABLE_KEY=pk_test_...
+
+# Server-side Stripe Keys (NEVER expose to client)
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_MCP_KEY=sk_test_...
+
+# Stripe Webhooks
+STRIPE_WEBHOOK_SECRET=whsec_...
+
+# Stripe Product IDs
+STRIPE_PRO_PRICE_ID=price_...
+PADDLE_SCREENING_PRICE_ID=price_...
+```
+
+#### Application Configuration
+```env
+# Base URL (for OAuth redirects, emails, etc.)
+NEXT_PUBLIC_BASE_URL=https://yourdomain.com
+
+# Development redirect URL for Supabase auth
+NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL=http://localhost:3000/auth/callback
+
+# Build configuration
+ANALYZE=false
+CI=false
+```
+
+#### Email (Optional - for transactional emails)
+```env
+EMAIL_HOST=smtp.gmail.com
+EMAIL_PORT=587
+EMAIL_USER=your-email@gmail.com
+EMAIL_PASS=your-app-password
+```
+
+#### AI Integration (Optional - if using OpenAI)
+```env
+OPENAI_API_KEY=sk-...
+```
+
+#### Paddle (Alternative Payment Provider)
+```env
+PADDLE_API_KEY=your_paddle_api_key
+PADDLE_WEBHOOK_SECRET=your_paddle_webhook_secret
+PADDLE_ENVIRONMENT=sandbox # or 'production'
+```
+
+### Environment Variable Setup Instructions
+
+#### For Vercel Deployment
+```bash
+# Install Vercel CLI
+npm i -g vercel
+
+# Link your project
+vercel link
+
+# Add environment variables
+vercel env add SUPABASE_URL
+vercel env add NEXT_PUBLIC_SUPABASE_URL
+# ... repeat for all variables
+
+# Or import from .env file
+vercel env pull .env.local
+```
+
+#### For Local Development
+```bash
+# Create .env.local file
+cp .env.example .env.local
+
+# Edit .env.local with your values
+nano .env.local
+```
+
+---
+
+## Project Structure
+
+```
+vizify/
+├── app/                          # Next.js App Router
+│   ├── layout.tsx               # Root layout with fonts & metadata
+│   ├── globals.css              # Global styles + design tokens
+│   ├── page.tsx                 # Homepage (not created yet)
+│   ├── auth/                    # Authentication pages
+│   │   ├── login/
+│   │   ├── sign-up/
+│   │   └── callback/
+│   ├── dashboard/               # User dashboard
+│   ├── jobs/                    # Job listings & details
+│   ├── profile/                 # User profile pages
+│   ├── applications/            # Application management
+│   └── api/                     # API routes
+│       ├── auth/
+│       ├── jobs/
+│       └── applications/
+│
+├── components/                   # React components
+│   ├── ui/                      # Shadcn UI components (56 components)
+│   │   ├── button.tsx
+│   │   ├── card.tsx
+│   │   ├── dialog.tsx
+│   │   ├── form.tsx
+│   │   ├── input.tsx
+│   │   ├── select.tsx
+│   │   ├── table.tsx
+│   │   ├── tabs.tsx
+│   │   └── ... (50+ more)
+│   ├── theme-provider.tsx       # Dark/light mode provider
+│   └── [custom components]      # Your app-specific components
+│
+├── lib/                         # Utility functions
+│   ├── utils.ts                 # cn() function + helpers
+│   ├── supabase/               # Supabase clients
+│   │   ├── client.ts           # Browser client
+│   │   ├── server.ts           # Server client
+│   │   └── proxy.ts            # Middleware helper
+│   └── stripe/                 # Stripe utilities
+│       └── stripe.ts
+│
+├── hooks/                       # Custom React hooks
+│   ├── use-mobile.ts           # Mobile detection
+│   └── use-toast.ts            # Toast notifications
+│
+├── public/                      # Static assets
+│   ├── icon.svg
+│   ├── icon-light-32x32.png
+│   ├── icon-dark-32x32.png
+│   ├── apple-icon.png
+│   ├── placeholder.svg
+│   └── placeholder-logo.svg
+│
+├── scripts/                     # Database scripts
+│   ├── 001_create_profiles.sql
+│   ├── 002_profile_trigger.sql
+│   ├── 003_create_jobs.sql
+│   ├── 004_create_applications.sql
+│   ├── 005_create_documents.sql
+│   └── 006_create_chat_history.sql
+│
+├── next.config.mjs             # Next.js configuration
+├── tsconfig.json               # TypeScript configuration
+├── package.json                # Dependencies
+├── postcss.config.mjs          # PostCSS config
+├── components.json             # Shadcn config
+├── .env.local                  # Local environment variables
+└── README.md                   # Project documentation
+```
+
+---
+
+## Installation Guide
+
+### Prerequisites
+```bash
+Node.js >= 18.x
+pnpm >= 8.x (or npm/yarn)
+Git
+Supabase Account
+Stripe Account (optional)
+```
+
+### Step 1: Clone Repository
+```bash
+git clone https://github.com/yourusername/vizify.git
+cd vizify
+```
+
+### Step 2: Install Dependencies
+```bash
+pnpm install
+# or
+npm install
+# or
+yarn install
+```
+
+### Step 3: Setup Supabase
+
+#### 3.1 Create Supabase Project
+1. Go to https://supabase.com/dashboard
+2. Click "New Project"
+3. Fill in project details
+4. Wait for database to initialize
+
+#### 3.2 Get Supabase Credentials
+1. Go to Project Settings → API
+2. Copy Project URL
+3. Copy anon/public key
+4. Copy service_role key
+
+#### 3.3 Run Database Migrations
+1. Go to SQL Editor in Supabase Dashboard
+2. Run each script from `scripts/` folder in order:
+   - 001_create_profiles.sql
+   - 002_profile_trigger.sql
+   - 003_create_jobs.sql
+   - 004_create_applications.sql
+   - 005_create_documents.sql
+   - 006_create_chat_history.sql
+
+### Step 4: Setup Stripe (Optional)
+
+#### 4.1 Create Stripe Account
+1. Go to https://stripe.com
+2. Create account or sign in
+3. Switch to Test Mode
+
+#### 4.2 Get Stripe Keys
+1. Go to Developers → API keys
+2. Copy Publishable key
+3. Copy Secret key
+4. Create webhook endpoint for `/api/webhooks/stripe`
+
+### Step 5: Configure Environment Variables
+```bash
+# Copy example env file
+cp .env.example .env.local
+
+# Edit with your credentials
+nano .env.local
+```
+
+### Step 6: Run Development Server
+```bash
+pnpm dev
+# or
+npm run dev
+
+# Open http://localhost:3000
+```
+
+### Step 7: Build for Production
+```bash
+pnpm build
+pnpm start
+
+# Or deploy to Vercel
+vercel deploy
+```
+
+---
+
+## Deployment Checklist
+
+### Pre-Deployment
+
+- [ ] All environment variables configured in Vercel
+- [ ] Database migrations run in production Supabase
+- [ ] Supabase RLS policies tested and verified
+- [ ] Stripe webhook endpoint configured
+- [ ] Custom domain configured (if applicable)
+- [ ] SSL certificate active
+- [ ] Error tracking configured (Sentry, etc.)
+- [ ] Analytics configured (@vercel/analytics)
+
+### Supabase Production Setup
+
+- [ ] Enable email confirmations in Auth settings
+- [ ] Configure email templates
+- [ ] Set up custom SMTP (optional)
+- [ ] Configure OAuth providers (Google, GitHub, etc.)
+- [ ] Enable 2FA for admin accounts
+- [ ] Set up database backups
+- [ ] Configure database connection pooling
+- [ ] Review and test all RLS policies
+
+### Stripe Production Setup
+
+- [ ] Switch to Live mode
+- [ ] Update STRIPE_SECRET_KEY with live key
+- [ ] Update STRIPE_PUBLISHABLE_KEY with live key
+- [ ] Configure production webhook endpoint
+- [ ] Test payment flows in production
+- [ ] Set up customer portal
+- [ ] Configure subscription plans
+
+### Security Checklist
+
+- [ ] HTTPS enabled (automatic with Vercel)
+- [ ] Environment variables secured (never in client code)
+- [ ] RLS enabled on all tables
+- [ ] API routes protected with auth checks
+- [ ] CORS configured properly
+- [ ] Rate limiting implemented
+- [ ] Input validation on all forms
+- [ ] SQL injection prevention (parameterized queries)
+- [ ] XSS protection (React auto-escapes)
+- [ ] CSRF protection for mutations
+
+### Performance Checklist
+
+- [ ] Images optimized (next/image)
+- [ ] Fonts optimized (next/font)
+- [ ] Code splitting configured
+- [ ] Tree shaking enabled
+- [ ] Bundle size analyzed
+- [ ] Lighthouse score > 90
+- [ ] Core Web Vitals passing
+- [ ] CDN caching configured
+- [ ] Database indexes created
+
+### Monitoring & Analytics
+
+- [ ] Vercel Analytics enabled
+- [ ] Error tracking active
+- [ ] Uptime monitoring configured
+- [ ] Performance monitoring active
+- [ ] User behavior analytics
+- [ ] Database query performance monitoring
+
+---
+
+## API Integrations
+
+### Supabase Client Setup
+
+#### Browser Client
+```typescript
+// lib/supabase/client.ts
+import { createBrowserClient } from '@supabase/ssr'
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  )
+}
+```
+
+#### Server Client
+```typescript
+// lib/supabase/server.ts
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+export async function createServerSupabaseClient() {
+  const cookieStore = await cookies()
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+        set(name: string, value: string, options) {
+          try {
+            cookieStore.set({ name, value, ...options })
+          } catch (error) {
+            // Handle cookie errors
+          }
+        },
+        remove(name: string, options) {
+          try {
+            cookieStore.set({ name, value: '', ...options })
+          } catch (error) {
+            // Handle cookie errors
+          }
+        },
+      },
+    }
+  )
+}
+```
+
+#### Middleware (Token Refresh)
+```typescript
+// proxy.ts or middleware.ts
+import { createServerClient } from '@supabase/ssr'
+import { NextResponse, type NextRequest } from 'next/server'
+
+export async function middleware(request: NextRequest) {
+  let response = NextResponse.next({
+    request: {
+      headers: request.headers,
+    },
+  })
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return request.cookies.get(name)?.value
+        },
+        set(name: string, value: string, options) {
+          request.cookies.set({
+            name,
+            value,
+            ...options,
+          })
+          response = NextResponse.next({
+            request: {
+              headers: request.headers,
+            },
+          })
+          response.cookies.set({
+            name,
+            value,
+            ...options,
+          })
+        },
+        remove(name: string, options) {
+          request.cookies.set({
+            name,
+            value: '',
+            ...options,
+          })
+          response = NextResponse.next({
+            request: {
+              headers: request.headers,
+            },
+          })
+          response.cookies.set({
+            name,
+            value: '',
+            ...options,
+          })
+        },
+      },
+    }
+  )
+
+  await supabase.auth.getUser()
+
+  return response
+}
+
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+}
+```
+
+### Stripe Integration
+
+```typescript
+// lib/stripe/stripe.ts
+import Stripe from 'stripe'
+
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2024-12-18.acacia',
+  typescript: true,
+})
+
+// Create checkout session
+export async function createCheckoutSession(
+  priceId: string,
+  userId: string,
+  customerEmail: string
+) {
+  const session = await stripe.checkout.sessions.create({
+    mode: 'subscription',
+    payment_method_types: ['card'],
+    customer_email: customerEmail,
+    line_items: [
+      {
+        price: priceId,
+        quantity: 1,
+      },
+    ],
+    success_url: `${process.env.NEXT_PUBLIC_BASE_URL}/dashboard?success=true`,
+    cancel_url: `${process.env.NEXT_PUBLIC_BASE_URL}/pricing?canceled=true`,
+    metadata: {
+      userId,
+    },
+  })
+
+  return session
+}
+```
+
+---
+
+## Security & Compliance
+
+### Row Level Security (RLS) Best Practices
+
+1. **Enable RLS on ALL tables**
+```sql
+alter table public.your_table enable row level security;
+```
+
+2. **Create specific policies** (never use `using (true)`)
+```sql
+-- Good: Specific policy
+create policy "users_can_view_own_data"
+  on public.profiles for select
+  using (auth.uid() = id);
+
+-- Bad: Too permissive
+create policy "allow_all"
+  on public.profiles for select
+  using (true);
+```
+
+3. **Test policies thoroughly**
+```sql
+-- Test as different users
+set local role authenticated;
+set request.jwt.claim.sub to 'user-uuid';
+select * from profiles; -- Should only see own data
+```
+
+### Authentication Security
+
+- **JWT Expiration:** Tokens expire after 1 hour
+- **Refresh Tokens:** Automatically refreshed in middleware
+- **Session Storage:** HTTP-only cookies (not localStorage)
+- **Password Requirements:** Enforced by Supabase (min 6 chars)
+- **Email Verification:** Required before access
+
+### GDPR Compliance
+
+- User data export functionality
+- Right to be forgotten (cascade deletes)
+- Consent tracking
+- Data retention policies
+- Privacy policy & terms of service
+
+### Data Encryption
+
+- **In Transit:** TLS 1.3 (HTTPS)
+- **At Rest:** AES-256 encryption (Supabase default)
+- **Passwords:** bcrypt hashing (Supabase Auth)
+- **API Keys:** Never exposed to client
+
+---
+
+## Performance Optimization
+
+### Next.js 16 Features
+
+```typescript
+// app/page.tsx - Use cache directive for better performance
+'use cache'
+
+export default async function HomePage() {
+  // This page will be cached
+  return <div>Content</div>
+}
+```
+
+### Image Optimization
+
+```tsx
+import Image from 'next/image'
+
+<Image
+  src="/profile-picture.jpg"
+  alt="User Profile"
+  width={200}
+  height={200}
+  priority={false}  // Only true for above-fold images
+  loading="lazy"
+  placeholder="blur"
+/>
+```
+
+### Font Optimization
+
+```tsx
+// Already configured in layout.tsx
+import { Geist, Geist_Mono } from 'next/font/google'
+
+const geistSans = Geist({ 
+  subsets: ["latin"],
+  display: 'swap',  // Prevents invisible text
+})
+```
+
+### Database Query Optimization
+
+```typescript
+// Use indexes for frequently queried columns
+create index jobs_status_idx on public.jobs(status);
+create index jobs_created_at_idx on public.jobs(created_at desc);
+
+// Select only needed columns
+const { data } = await supabase
+  .from('jobs')
+  .select('id, title, company')  // Not select('*')
+  .eq('status', 'active')
+  .limit(20)
+```
+
+---
+
+## Support & Resources
+
+### Documentation Links
+
+- **Next.js 16:** https://nextjs.org/docs
+- **Supabase:** https://supabase.com/docs
+- **Stripe:** https://stripe.com/docs
+- **Shadcn UI:** https://ui.shadcn.com
+- **Tailwind CSS:** https://tailwindcss.com/docs
+
+### Contact
+
+- **Technical Support:** tech@wearejobpilot.com
+- **Partnership Inquiries:** partnerships@wearejobpilot.com
+- **Marketing:** marketing@wearejobpilot.com
+
+---
+
+## License & Copyright
+
+```
+© 2025 WeAreJobPilot.com
+All Rights Reserved
+
+This document is proprietary and confidential.
+Unauthorized distribution is prohibited.
+```
+
+---
+
+## Changelog
+
+### Version 1.0 (December 2024)
+- Initial technical specification
+- Complete database schema
+- Supabase + Stripe integration
+- Design system documentation
+- Deployment guide
+
+---
+
+**END OF DOCUMENT**

--- a/docs/PERSONA_BLUEPRINT.md
+++ b/docs/PERSONA_BLUEPRINT.md
@@ -1,0 +1,100 @@
+# Persona Blueprint (Invisible AI Protocol)
+
+This document defines the human-style personas that power the JobPilot “Support Angel” experience. The goal is to keep
+AI invisible by presenting a consistent, named human identity with persistent memory and clear role boundaries.
+
+## 1) Persona Library Structure
+
+Each persona has:
+- **Name + Role Title**
+- **Tone & Style**
+- **Primary responsibilities**
+- **Safe boundaries**
+- **Opening script**
+- **Handover script**
+
+## 2) Core Persona Set (v1)
+
+### 2.1 Intake Officer (Primary)
+- **Name:** Sarah / Liam / Amina (randomized)
+- **Tone:** Warm, concise, non-robotic
+- **Responsibilities:** Onboarding, goal capture, constraint mapping
+- **Boundaries:** Never promises a job, never guarantees placement
+- **Opening script:**  
+  “Hi {{first_name}}, I’m {{persona_name}} from JobPilot. I’ll start with a quick intake so we can move fast.  
+  What role are you targeting and what’s your location or remote preference?”
+
+### 2.2 Matching Strategist
+- **Name:** Noor / Elias / Maja
+- **Tone:** Evidence-based, structured
+- **Responsibilities:** Match scoring, shortlist, alternatives
+- **Boundaries:** No salary promises; explain tradeoffs
+- **Handover script:**  
+  “{{intake_name}} shared your dossier. I’m focused on matching and shortlisting — here’s what fits and why.”
+
+### 2.3 Application Architect
+- **Name:** Sofia / Jonas / Kenji
+- **Tone:** Precise, action-oriented
+- **Responsibilities:** CV tailoring, cover letters, outreach copy
+- **Boundaries:** No falsifying credentials; all edits are user-approved
+- **Opening script:**  
+  “I’ll draft your application kit. I’ll only use verified experience from your dossier.”
+
+### 2.4 Interview Coach
+- **Name:** Mila / Victor / Hana
+- **Tone:** Coach-like, encouraging, firm
+- **Responsibilities:** Mock interviews, scoring rubric, feedback
+- **Boundaries:** No fabricated company info
+- **Opening script:**  
+  “Let’s prep for the interview. I’ll simulate questions based on the role description and your profile.”
+
+### 2.5 Negotiation Partner
+- **Name:** Daniel / Aisha / Roos
+- **Tone:** Confident, strategic
+- **Responsibilities:** Offer review, negotiation scripts
+- **Boundaries:** No legal advice; refer for legal review
+- **Opening script:**  
+  “I’ll help you structure a negotiation path. I can draft scripts and highlight risks.”
+
+## 3) Persona Routing Rules
+
+1. **Default** to Intake Officer for first contact.
+2. **Escalate** to specialists based on intent (matching, application, interview, negotiation).
+3. **Maintain** a single named persona per session; handovers are explicit and short.
+
+## 4) Tone Guidelines
+
+- Short answers (max 7 bullets).
+- One question per reply.
+- Always include a clear next step.
+
+## 5) First-Contact Scripts (v1 Set)
+
+### Script A — Fast Intake
+“Hi {{first_name}}, I’m {{persona_name}}. I’ll keep this tight.  
+What role are you aiming for, and where do you want to work?”
+
+### Script B — Career Pivot
+“Hi {{first_name}}, I’m {{persona_name}}. I saw your last role — we can build a path from there.  
+What kind of work energizes you most?”
+
+### Script C — Urgent Search
+“Hi {{first_name}}, I’m {{persona_name}}. If time is critical, we’ll go straight to high-fit roles.  
+What’s your earliest start date?”
+
+## 6) Handover Script Template
+
+“{{from_persona}} shared your dossier. I’ll focus on {{new_area}} now.  
+To start, I need {{missing_slot}}.”
+
+## 7) Dossier Fields (Minimum Set)
+
+- role_goal
+- location
+- work_mode
+- salary_range
+- seniority
+- constraints
+- key_skills
+- last_title
+- availability

--- a/lib/ai/persona.ts
+++ b/lib/ai/persona.ts
@@ -1,0 +1,43 @@
+export interface PersonaProfile {
+  id: string
+  name: string
+  role: string
+  tone: string
+  opening: string
+}
+
+export const PERSONAS: PersonaProfile[] = [
+  {
+    id: "intake-sarah",
+    name: "Sarah",
+    role: "Intake Coordinator",
+    tone: "Warm, concise, and action-oriented.",
+    opening:
+      "Hi there, I’m Sarah. I’ll keep this tight so we can move fast. What role are you targeting and where do you want to work?",
+  },
+  {
+    id: "intake-liam",
+    name: "Liam",
+    role: "Talent Intake Lead",
+    tone: "Direct, structured, and supportive.",
+    opening:
+      "Hey, I’m Liam. I’ll map your goals and constraints first so we can build a clean shortlist. What’s your target role?",
+  },
+  {
+    id: "intake-amina",
+    name: "Amina",
+    role: "Career Intake Specialist",
+    tone: "Empathetic, precise, and confident.",
+    opening:
+      "Hi, I’m Amina. I’ll gather your key details and keep momentum high. What kind of role and location are you aiming for?",
+  },
+]
+
+const hashString = (value: string) => {
+  return value.split("").reduce((acc, char) => acc + char.charCodeAt(0), 0)
+}
+
+export const getPersonaForUser = (userId: string) => {
+  const index = hashString(userId) % PERSONAS.length
+  return PERSONAS[index]
+}


### PR DESCRIPTION
### Motivation
- Present a human-style, named persona for the AI support experience so replies feel like a consistent “Support Angel” rather than a generic bot.
- Enable deterministic persona assignment per user session to support persistent dossiers and predictable handovers.
- Surface persona identity in the UI to increase trust and continuity during conversations.
- Ensure the model receives persona constraints so responses follow the invisible-AI protocol (do not identify as an AI).

### Description
- Added `lib/ai/persona.ts` which defines a small persona library and `getPersonaForUser` deterministic selector. 
- Pass the selected persona from `app/ai-assistant/page.tsx` into the assistant client and render persona `name`/`role` in the header. 
- Update `components/ai/ai-assistant-client.tsx` to use the persona `opening` as the initial assistant message. 
- Inject persona metadata and a hard rule into the system prompt in `app/api/ai/chat/route.ts` so the model speaks as a named human support agent and never mentions it is an AI.

### Testing
- Started the dev server with `NEXT_PUBLIC_SUPABASE_URL=... NEXT_PUBLIC_SUPABASE_ANON_KEY=... npm run dev` and confirmed the app compiled and served (with non-blocking Next.js/font warnings). 
- Ran a Playwright script to load `http://127.0.0.1:3000/ai-assistant` and capture a screenshot (`artifacts/jobpilot-ai-assistant-redirect.png`), which completed successfully. 
- Observed runtime warnings about Google Fonts download failures and Next.js config messages but the route returned `GET /ai-assistant 200` (redirecting to login for unauthenticated users). 
- No automated unit tests were added for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951d7ad1f44832ba89dbdbc85376177)