### PR TITLE
Add DJ Kenneth booking presskit page (public/dj-kenneth-epk.html)

### DIFF
--- a/public/dj-kenneth-epk.html
+++ b/public/dj-kenneth-epk.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>DJ Kenneth × Partysoldiers — Booking Presskit</title>
+  <meta name="description" content="One-link scrollable booking presskit for DJ Kenneth × Partysoldiers with catalog, media, and booking intake." />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Cormorant+Garamond:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    :root{--bg:#090b14;--bg2:#121423;--txt:#ececf2;--muted:#9fa3b8;--line:rgba(236,236,242,.12);--blue:#4d8de8;--red:#e85a3a}
+    *{box-sizing:border-box;margin:0;padding:0}html{scroll-behavior:smooth}body{font-family:'Cormorant Garamond',serif;background:radial-gradient(circle at 20% 20%,rgba(77,141,232,.12),transparent 40%),radial-gradient(circle at 80% 80%,rgba(232,90,58,.08),transparent 40%),var(--bg);color:var(--txt)}
+    .wrap{max-width:1240px;margin:auto;padding:0 24px}.section{padding:88px 0;border-top:1px solid var(--line)}
+    .k{font:500 11px 'JetBrains Mono',monospace;letter-spacing:.22em;text-transform:uppercase;color:var(--red);margin-bottom:14px}
+    h1,h2,h3{font-family:'Bebas Neue',sans-serif;letter-spacing:.03em;line-height:.95}.lead{color:var(--muted);max-width:64ch}
+    .hero{min-height:95vh;display:grid;grid-template-columns:1.1fr .9fr}.hero .img{position:relative}.hero img{width:100%;height:100%;object-fit:cover;filter:contrast(1.05) saturate(.95)}
+    .hero .img:after,.duo:after{content:'';position:absolute;inset:0;background:linear-gradient(130deg,rgba(77,141,232,.22),transparent 52%,rgba(232,90,58,.2));mix-blend-mode:overlay}
+    .hero-copy{padding:60px 52px;display:flex;flex-direction:column;justify-content:center;background:var(--bg2)}
+    .hero h1{font-size:clamp(3.2rem,9vw,8rem)} .hero .tag{font-size:clamp(1.4rem,2.8vw,2.4rem);font-style:italic;margin:14px 0 24px}
+    .stats{display:flex;flex-wrap:wrap;gap:14px 28px;font:500 10px 'JetBrains Mono',monospace;letter-spacing:.2em;text-transform:uppercase;color:var(--muted);margin:30px 0}
+    .btn{display:inline-block;padding:12px 16px;border:1px solid var(--red);font:500 12px 'JetBrains Mono',monospace;letter-spacing:.16em;text-transform:uppercase;color:var(--txt);text-decoration:none}
+    .proof{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}.card{border:1px solid var(--line);padding:20px;background:rgba(255,255,255,.01)}.card h3{font-size:1.7rem}.card p{color:var(--muted)}
+    .music{display:grid;grid-template-columns:.95fr 1.05fr;gap:16px}.list{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:1px;background:var(--line);border:1px solid var(--line)}
+    .track{background:var(--bg);padding:18px}.track b{display:block;font-family:'Bebas Neue',sans-serif;font-size:1.45rem;line-height:1}.track span{color:var(--muted);font-size:.92rem}
+    .gallery{display:grid;grid-template-columns:repeat(12,1fr);grid-auto-rows:80px;gap:12px}.g1{grid-column:span 7;grid-row:span 5}.g2{grid-column:span 5;grid-row:span 3}.g3{grid-column:span 5;grid-row:span 3}.g4{grid-column:span 7;grid-row:span 3}
+    .gallery .duo{position:relative;overflow:hidden;background:#000}.gallery img{width:100%;height:100%;object-fit:cover;filter:contrast(1.05) brightness(.95)}
+    .links{border-top:1px solid var(--line)}.ln{display:grid;grid-template-columns:40px 1fr auto;gap:16px;padding:16px 0;border-bottom:1px solid var(--line);text-decoration:none;color:inherit}.ln:hover{background:rgba(77,141,232,.06)}.ln em{color:var(--muted);font-style:italic}
+    form{display:grid;grid-template-columns:1fr 1fr;gap:10px}input,select,textarea{background:#0f1220;color:var(--txt);border:1px solid var(--line);padding:12px;font:400 14px 'JetBrains Mono',monospace}textarea{grid-column:1/-1;min-height:110px}button{grid-column:1/-1;background:var(--red);color:#fff;border:0;padding:13px;font:500 12px 'JetBrains Mono',monospace;letter-spacing:.16em;text-transform:uppercase}
+    .fixed{position:fixed;right:18px;bottom:18px;z-index:9}
+    @media(max-width:960px){.hero{grid-template-columns:1fr}.music{grid-template-columns:1fr}.gallery{grid-template-columns:repeat(6,1fr)}.g1,.g2,.g3,.g4{grid-column:span 6}.section{padding:64px 0}form{grid-template-columns:1fr}}
+  </style>
+</head>
+<body>
+  <a class="btn fixed" href="#book">Book Now</a>
+  <header class="hero" id="overview">
+    <div class="img"><img src="img-00-vault.jpg" alt="DJ Kenneth hero image" loading="eager" fetchpriority="high"></div>
+    <div class="hero-copy">
+      <div class="k">Booking Presskit · One Link Catalog</div>
+      <h1>DJ Kenneth <span style="background:linear-gradient(90deg,var(--blue),var(--red));-webkit-background-clip:text;color:transparent">Partysoldiers</span></h1>
+      <p class="tag">From another planet.</p>
+      <p class="lead">Legacy DJ + producer + crew leader. International touring history, Dutch Bubbling foundation, and an active multi-release catalog distributed via DistroKid.</p>
+      <div class="stats"><span>600K+ sales legacy</span><span>15 years · 3 bookings/week avg</span><span>Wrocław base</span><span>VIVA award</span></div>
+      <a class="btn" href="#book">Booking / Offer Form</a>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <section class="section" id="proof"><div class="k">Proof / Credibility</div><div class="proof">
+      <article class="card"><h3>Shared Stages</h3><p>Method Man · Lil Wayne · Redman · Wu-Tang related acts.</p></article>
+      <article class="card"><h3>Legacy</h3><p>Pioneer era in Dutch Bubbling with strong historical sales impact.</p></article>
+      <article class="card"><h3>Residency</h3><p>Mundo 71 Wrocław since opening period.</p></article>
+      <article class="card"><h3>Circuits</h3><p>Poland, Germany, Netherlands + international touring footprint.</p></article>
+    </div></section>
+
+    <section class="section" id="music"><div class="k">Music / Full Portfolio (not single-track)</div><p class="lead" style="margin-bottom:20px">Catalog weight is on the broader Partysoldiers universe (J+K, Hobysoft, Ayome and wider releases), not only one release.</p><div class="music">
+      <iframe title="Spotify playlist" src="https://open.spotify.com/embed/playlist/5RgTX2d4wRFnARbxmISWnh?utm_source=generator&theme=0" width="100%" height="380" loading="lazy" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>
+      <div class="list">
+        <div class="track"><b>Where the F_c_k iam</b><span>Partysoldiers, Anna Matowicz</span></div>
+        <div class="track"><b>Nekita</b><span>Partysoldiers</span></div>
+        <div class="track"><b>2 Proud 2 Begg</b><span>Partysoldiers</span></div>
+        <div class="track"><b>Wictoria Secret</b><span>feat. Mr. Von / Raul Moro versions</span></div>
+        <div class="track"><b>From Another Planet</b><span>Partysoldiers</span></div>
+        <div class="track"><b>Fuego Y Ritmo</b><span>Raul Moro & Luis Fondora</span></div>
+        <div class="track"><b>Toxic</b><span>it's Mano · Partysoldiers production sphere</span></div>
+        <div class="track"><b>Baila Bubbel / Mundo 71</b><span>Catalog projects · DistroKid distribution</span></div>
+      </div>
+    </div></section>
+
+    <section class="section" id="visuals"><div class="k">Visuals / Live Energy</div><div class="gallery">
+      <div class="duo g1"><img src="img-05-crowd.jpg" alt="Live crowd energy" loading="lazy"></div>
+      <div class="duo g2"><img src="img-03-bio.jpg" alt="Artist portrait" loading="lazy"></div>
+      <div class="duo g3"><img src="img-04-mic.jpg" alt="Live mic performance" loading="lazy"></div>
+      <div class="duo g4"><img src="img-08-crew.jpg" alt="Partysoldiers crew" loading="lazy"></div>
+    </div></section>
+
+    <section class="section" id="listen"><div class="k">Listen / Platforms</div><div class="links">
+      <a class="ln" href="https://open.spotify.com/artist/2xTK2wpo2lHpEeEbpLBkYf" target="_blank" rel="noopener"><span>01</span><div>Spotify · Partysoldiers<br><em>Artist catalog</em></div><span>↗</span></a>
+      <a class="ln" href="https://open.spotify.com/artist/3GU9wt0xH9QE2KwWAbGtvQ" target="_blank" rel="noopener"><span>02</span><div>Spotify · DJ Kenneth A.<br><em>Solo/production profile</em></div><span>↗</span></a>
+      <a class="ln" href="https://www.youtube.com/channel/UCrwadrfGx27p3JNfR0kCxRQ" target="_blank" rel="noopener"><span>03</span><div>YouTube · Mundo TV 71<br><em>Archive / live footage</em></div><span>↗</span></a>
+      <a class="ln" href="https://www.youtube.com/@dj_kenneth" target="_blank" rel="noopener"><span>04</span><div>YouTube · DJ Kenneth Partysoldiers<br><em>Mixes & clips</em></div><span>↗</span></a>
+      <a class="ln" href="https://soundcloud.com/dj_kenneth_hol" target="_blank" rel="noopener"><span>05</span><div>SoundCloud · dj_kenneth_hol</div><span>↗</span></a>
+      <a class="ln" href="https://www.mixcloud.com/kenneth-vreden/" target="_blank" rel="noopener"><span>06</span><div>Mixcloud · Kenneth Vreden</div><span>↗</span></a>
+      <a class="ln" href="https://distrokid.com/hyperfollow/partysoldiers/mundo-71" target="_blank" rel="noopener"><span>07</span><div>DistroKid · Distribution entry</div><span>↗</span></a>
+      <a class="ln" href="https://www.instagram.com/djkennethhol/" target="_blank" rel="noopener"><span>08</span><div>Instagram · @djkennethhol</div><span>↗</span></a>
+      <a class="ln" href="https://www.facebook.com/Partysoldiers/" target="_blank" rel="noopener"><span>09</span><div>Facebook · Partysoldiers</div><span>↗</span></a>
+    </div></section>
+
+    <section class="section" id="book"><div class="k">Book / Offer Request</div><p class="lead" style="margin-bottom:16px">Promoter sends event details here; your team responds by email with offer flow.</p>
+      <form id="bookingForm">
+        <input required name="name" placeholder="Your name" />
+        <input required type="email" name="email" placeholder="Your email" />
+        <input required name="event" placeholder="Event name" />
+        <input required type="date" name="date" />
+        <input name="city" placeholder="City / Country" />
+        <select name="type"><option>Club</option><option>Festival</option><option>Corporate</option><option>Private</option></select>
+        <textarea name="msg" placeholder="Budget, audience size, timing, technical rider notes..."></textarea>
+        <button type="submit">Send Booking Request</button>
+      </form>
+    </section>
+  </main>
+<script>
+  document.getElementById('bookingForm').addEventListener('submit', function(e){
+    e.preventDefault();
+    const d = Object.fromEntries(new FormData(e.target).entries());
+    const subject = encodeURIComponent(`Booking request · ${d.event||'DJ Kenneth'}`);
+    const body = encodeURIComponent(`Name: ${d.name}\nEmail: ${d.email}\nEvent: ${d.event}\nDate: ${d.date}\nCity/Country: ${d.city}\nType: ${d.type}\n\nDetails:\n${d.msg||''}`);
+    window.location.href = `mailto:kenneth.psevents@gmail.com?subject=${subject}&body=${body}`;
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a single-file, one-link booking presskit for DJ Kenneth × Partysoldiers to surface catalog, media, credibility, and a simple booking intake form.
- Ship a lightweight static page that can be hosted under `public/` and linked from social or promo channels.

### Description
- Add `public/dj-kenneth-epk.html`, a complete static HTML presskit with embedded styles, responsive layout, and Google fonts for typography.
- Include hero, proof/credentials, music (Spotify embed + track list), visuals gallery, platform links, and a booking form that uses a `mailto:` flow assembled in client-side JavaScript.
- Use grid-based responsive CSS, image placeholders (`img-*.jpg`) and external embeds/links for Spotify, YouTube, SoundCloud, Mixcloud, DistroKid, Instagram, and Facebook.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f633eef9e0832ba6b63c57f3e192d3)